### PR TITLE
Add edit option to inventory sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,24 @@ export default function App() {
     }
   }
 
+  // Редактирование объекта
+  async function editObject(obj) {
+    const name = prompt('Введите новое название объекта:', obj.name);
+    if (!name) return;
+    const { data, error } = await supabase
+      .from('objects')
+      .update({ name })
+      .eq('id', obj.id)
+      .select()
+      .single();
+    if (error) {
+      alert('Ошибка редактирования: ' + error.message);
+    } else {
+      setObjects(prev => prev.map(o => (o.id === obj.id ? data : o)));
+      if (selected?.id === obj.id) setSelected(data);
+    }
+  }
+
   function handleSelect(obj) {
     setSelected(obj);
     setIsSidebarOpen(false);
@@ -91,6 +109,7 @@ export default function App() {
           objects={objects}
           selected={selected}
           onSelect={handleSelect}
+          onEdit={editObject}
           onDelete={deleteObject}
         />
       </aside>
@@ -111,6 +130,7 @@ export default function App() {
               objects={objects}
               selected={selected}
               onSelect={handleSelect}
+              onEdit={editObject}
               onDelete={deleteObject}
             />
           </aside>

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -4,6 +4,7 @@ export default function InventorySidebar({
   objects,
   selected,
   onSelect,
+  onEdit,
   onDelete
 }) {
   return (
@@ -22,6 +23,13 @@ export default function InventorySidebar({
             }`}
           >
             {o.name}
+          </button>
+          <button
+            onClick={() => onEdit(o)}
+            className="ml-2 text-blue-500 hover:text-blue-700"
+            title="Редактировать объект"
+          >
+            ✎
           </button>
           <button
             onClick={() => onDelete(o.id)}


### PR DESCRIPTION
## Summary
- add editObject handler for renaming objects
- expose edit button in InventorySidebar and pass handler from App

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689050c6a1c08324881a37b8d59d9fc2