### PR TITLE
feat: add username registration and mobile sidebar behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-theme="light">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -106,6 +106,8 @@ export default function App() {
 
   function handleSelect(obj) {
     setSelected(obj);
+    // закрываем сайдбар на мобильных устройствах после выбора объекта
+    setIsSidebarOpen(false);
   }
 
   function handleUpdateSelected(updated) {

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -4,6 +4,7 @@ import { supabase } from '../supabaseClient'
 export default function Auth() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [username, setUsername] = useState('')
   const [isRegister, setIsRegister] = useState(false)
   const [error, setError] = useState(null)
 
@@ -12,7 +13,7 @@ export default function Auth() {
     setError(null)
     let res
     if (isRegister) {
-      res = await supabase.auth.signUp({ email, password })
+      res = await supabase.auth.signUp({ email, password, options: { data: { username } } })
     } else {
       res = await supabase.auth.signInWithPassword({ email, password })
     }
@@ -34,6 +35,16 @@ export default function Auth() {
           onChange={e => setEmail(e.target.value)}
           required
         />
+        {isRegister && (
+          <input
+            type="text"
+            className="input input-bordered w-full"
+            placeholder="Имя пользователя"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            required
+          />
+        )}
         <input
           type="password"
           className="input input-bordered w-full"

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -8,6 +8,7 @@ export default function ChatTab({ selected, user }) {
   const [file, setFile] = useState(null)
   const [uploading, setUploading] = useState(false)
   const scrollRef = useRef(null)
+  const senderName = user.user_metadata?.username || user.email
 
   // Загрузка и подписка на новые сообщения
   useEffect(() => {
@@ -77,7 +78,7 @@ export default function ChatTab({ selected, user }) {
     const { data: inserted, error: msgErr } = await supabase
       .from('chat_messages')
       .insert([
-        { object_id: selected.id, sender: user.email,  content: newMessage.trim(), file_url: fileUrl }
+        { object_id: selected.id, sender: senderName,  content: newMessage.trim(), file_url: fileUrl }
       ])
       .select()
       .single()
@@ -108,11 +109,11 @@ export default function ChatTab({ selected, user }) {
         {messages.map(msg => (
           <div
             key={msg.id}
-            className={`flex mb-2 ${msg.sender === user.email ? 'justify-end' : 'justify-start'}`}
+            className={`flex mb-2 ${msg.sender === senderName ? 'justify-end' : 'justify-start'}`}
           >
             <div
               className={`max-w-[80%] sm:max-w-[60%] break-words p-3 rounded-lg shadow ${
-                msg.sender === user.email ? 'bg-blue-100 text-right' : 'bg-white text-left'
+                msg.sender === senderName ? 'bg-blue-100 text-right' : 'bg-white text-left'
               }`.replace(/\s+/g, ' ')}
             >
               <div className="text-xs text-gray-500 mb-1">


### PR DESCRIPTION
## Summary
- ensure light theme is applied by default
- hide sidebar on mobile after selecting an object
- collect username during registration and show it in chat messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ac9ec37083248be4a82522422e1d