### PR TITLE
feat: add account editing and chat enhancements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { supabase } from './supabaseClient';
 import InventorySidebar from './components/InventorySidebar';
 import InventoryTabs from './components/InventoryTabs';
 import Auth from './components/Auth';
+import AccountModal from './components/AccountModal';
 import { Toaster, toast } from 'react-hot-toast';
 
 export default function App() {
@@ -12,7 +13,8 @@ export default function App() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [newObjectName, setNewObjectName] = useState('');
-  const [deleteCandidate, setDeleteCandidate] = useState(null);
+    const [deleteCandidate, setDeleteCandidate] = useState(null);
+    const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -119,6 +121,10 @@ export default function App() {
     setIsSidebarOpen(prev => !prev);
   }
 
+  function handleUserUpdated(updated) {
+    setUser(updated);
+  }
+
   if (!user) return <Auth />;
 
   if (!selected) {
@@ -185,8 +191,13 @@ export default function App() {
                 ➕ Добавить
               </button>
             </div>
-            <button className="btn btn-sm" onClick={() => supabase.auth.signOut()}>Выйти</button>
-          </header>
+              <div className="flex items-center gap-2">
+                <button className="btn btn-sm" onClick={() => setIsAccountModalOpen(true)}>
+                  {user.user_metadata?.username || 'Аккаунт'}
+                </button>
+                <button className="btn btn-sm" onClick={() => supabase.auth.signOut()}>Выйти</button>
+              </div>
+            </header>
 
           {/* Контент табов */}
           <div className="flex-1 overflow-auto">
@@ -232,6 +243,14 @@ export default function App() {
               </div>
             </div>
           </div>
+        )}
+
+        {isAccountModalOpen && (
+          <AccountModal
+            user={user}
+            onClose={() => setIsAccountModalOpen(false)}
+            onUpdated={handleUserUpdated}
+          />
         )}
       </div>
     </>

--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function AccountModal({ user, onClose, onUpdated }) {
+  const [username, setUsername] = useState(user.user_metadata?.username || '');
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    const { data, error } = await supabase.auth.updateUser({ data: { username } });
+    setSaving(false);
+    if (error) {
+      alert('Ошибка обновления: ' + error.message);
+    } else {
+      onUpdated(data.user);
+      onClose();
+    }
+  }
+
+  return (
+    <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="modal-box relative w-full max-w-md">
+        <button className="btn btn-sm btn-circle absolute right-2 top-2" onClick={onClose}>✕</button>
+        <h3 className="font-bold text-lg mb-4">Редактирование аккаунта</h3>
+        <div className="space-y-4">
+          <div className="form-control">
+            <label className="label"><span className="label-text">Никнейм</span></label>
+            <input
+              type="text"
+              className="input input-bordered w-full"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="modal-action flex space-x-2">
+          <button className="btn btn-primary" onClick={save} disabled={saving}>Сохранить</button>
+          <button className="btn btn-ghost" onClick={onClose}>Отмена</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { supabase } from '../supabaseClient';
 import { v4 as uuidv4 } from 'uuid';
+import { linkifyText } from '../utils/linkify';
 
 export default function ChatTab({ selected, user }) {
   const [messages, setMessages] = useState([])
@@ -106,33 +107,43 @@ export default function ChatTab({ selected, user }) {
             Нет сообщений. Начните диалог.
           </div>
         )}
-        {messages.map(msg => (
-          <div
-            key={msg.id}
-            className={`flex mb-2 ${msg.sender === senderName ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-[80%] sm:max-w-[60%] break-words p-3 rounded-lg shadow ${
-                msg.sender === senderName ? 'bg-blue-100 text-right' : 'bg-white text-left'
-              }`.replace(/\s+/g, ' ')}
-            >
-              <div className="text-xs text-gray-500 mb-1">
-                {msg.sender} • {new Date(msg.created_at).toLocaleString()}
-              </div>
-              {msg.content && <div className="whitespace-pre-line mb-1">{msg.content}</div>}
-              {msg.file_url && (
-                <a
-                  href={msg.file_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-500 underline block"
+          {messages.map(msg => {
+            const isOwn = msg.sender === senderName;
+            return (
+              <div
+                key={msg.id}
+                className={`flex mb-2 ${isOwn ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[80%] sm:max-w-[60%] break-words p-3 shadow ${
+                    isOwn
+                      ? 'bg-green-100 text-right rounded-l-lg rounded-t-lg rounded-br-none'
+                      : 'bg-white text-left rounded-r-lg rounded-t-lg rounded-bl-none'
+                  }`.replace(/\s+/g, ' ')}
                 >
-                  📎 Прикреплённый файл
-                </a>
-              )}
-            </div>
-          </div>
-        ))}
+                  <div className="text-xs text-gray-500 mb-1">
+                    {msg.sender} • {new Date(msg.created_at).toLocaleString()}
+                  </div>
+                  {msg.content && (
+                    <div
+                      className="whitespace-pre-line break-words mb-1"
+                      dangerouslySetInnerHTML={{ __html: linkifyText(msg.content) }}
+                    />
+                  )}
+                  {msg.file_url && (
+                    <a
+                      href={msg.file_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 underline block"
+                    >
+                      📎 Прикреплённый файл
+                    </a>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         <div ref={scrollRef} />
       </div>
 

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -3,6 +3,7 @@ import { supabase } from '../supabaseClient';
 import HardwareCard from './HardwareCard';
 import TaskCard from './TaskCard';
 import ChatTab from './ChatTab';
+import { linkifyText } from '../utils/linkify';
 
 export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   // --- вкладки и описание ---
@@ -22,7 +23,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   const [loadingTasks, setLoadingTasks] = useState(false)
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false)
   const [editingTask, setEditingTask]   = useState(null)
-  const [taskForm, setTaskForm]         = useState({ title: '', status: 'запланировано' })
+  const [taskForm, setTaskForm]         = useState({ title: '', status: 'запланировано', assignee: '', due_date: '' })
+  const [showDatePicker, setShowDatePicker] = useState(false)
 
   // --- чаты ---
   const [chats, setChats]               = useState([])
@@ -102,11 +104,17 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   function openTaskModal(item = null) {
     if (item) {
       setEditingTask(item)
-      setTaskForm({ title: item.title, status: item.status })
+      setTaskForm({
+        title: item.title,
+        status: item.status,
+        assignee: item.assignee || '',
+        due_date: item.due_date || ''
+      })
     } else {
       setEditingTask(null)
-      setTaskForm({ title: '', status: 'запланировано' })
+      setTaskForm({ title: '', status: 'запланировано', assignee: '', due_date: '' })
     }
+    setShowDatePicker(false)
     setIsTaskModalOpen(true)
   }
   async function saveTask() {
@@ -156,7 +164,14 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
                 </div>
               </>
             ) : (
-              <p className="mt-2 whitespace-pre-line">{description || 'Нет описания'}</p>
+              description ? (
+                <p
+                  className="mt-2 whitespace-pre-line break-words"
+                  dangerouslySetInnerHTML={{ __html: linkifyText(description) }}
+                />
+              ) : (
+                <p className="mt-2">Нет описания</p>
+              )
             )}
           </div>
         )}
@@ -262,6 +277,28 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
                         value={taskForm.title}
                         onChange={e=>setTaskForm(f=>({...f,title:e.target.value}))}
                       />
+                    </div>
+                    <div className="form-control">
+                      <label className="label"><span className="label-text">Исполнитель</span></label>
+                      <input
+                        type="text"
+                        className="input input-bordered w-full"
+                        value={taskForm.assignee}
+                        onChange={e=>setTaskForm(f=>({...f,assignee:e.target.value}))}
+                      />
+                    </div>
+                    <div className="form-control">
+                      <label className="label flex items-center"><span className="label-text">Дата</span>
+                        <button type="button" className="ml-2 btn btn-ghost btn-xs" onClick={()=>setShowDatePicker(s=>!s)}>📅</button>
+                      </label>
+                      {showDatePicker && (
+                        <input
+                          type="date"
+                          className="input input-bordered w-full"
+                          value={taskForm.due_date}
+                          onChange={e=>setTaskForm(f=>({...f,due_date:e.target.value}))}
+                        />
+                      )}
                     </div>
                     <div className="form-control">
                       <label className="label"><span className="label-text">Статус</span></label>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,6 +51,13 @@ export default function TaskCard({ item, onEdit, onDelete }) {
     <div className="flex justify-between items-center p-3 border rounded-lg hover:bg-base-200 transition">
       <div className="flex-1">
         <p className="break-words">{item.title}</p>
+        {(item.assignee || item.due_date) && (
+          <p className="text-sm text-gray-500">
+            {item.assignee && <span>👤 {item.assignee}</span>}
+            {item.assignee && item.due_date && ' • '}
+            {item.due_date && <span>📅 {item.due_date}</span>}
+          </p>
+        )}
       </div>
       <div className="flex items-center space-x-2">
         <span className={`badge ${badgeClass}`}>{item.status}</span>

--- a/src/utils/linkify.js
+++ b/src/utils/linkify.js
@@ -1,0 +1,10 @@
+export function linkifyText(text = '') {
+  const urlRegex = /((https?:\/\/|www\.)[^\s]+)/g;
+  return text.replace(urlRegex, url => {
+    let href = url;
+    if (!href.match(/^https?:\/\//)) {
+      href = 'http://' + href;
+    }
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-blue-500 underline">${url}</a>`;
+  });
+}


### PR DESCRIPTION
## Summary
- enable editing username via in-app account modal
- support task assignees and due dates with optional calendar picker
- make links clickable in descriptions and chat, and style chat bubbles like messaging apps

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6891b8c8d2d88324a0064f3d780c3c67