### PR TITLE
feat: restyle chat with WhatsApp-like UI

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -3,6 +3,40 @@ import { supabase } from '../supabaseClient';
 import { v4 as uuidv4 } from 'uuid';
 import { linkifyText } from '../utils/linkify';
 
+const PaperClipIcon = ({ className = 'w-6 h-6' }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      d="M18.375 12.739L10.682 20.432C8.92462 22.1893 6.07538 22.1893 4.31802 20.432C2.56066 18.6746 2.56066 15.8254 4.31802 14.068L15.2573 3.12868C16.4289 1.95711 18.3283 1.95711 19.4999 3.12868C20.6715 4.30025 20.6715 6.19975 19.4999 7.37132L8.55158 18.3197M8.56066 18.3107C8.55764 18.3137 8.55462 18.3167 8.55158 18.3197M14.2498 8.37865L6.43934 16.1893C5.85355 16.7751 5.85355 17.7249 6.43934 18.3107C7.02211 18.8934 7.9651 18.8964 8.55158 18.3197"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const PaperAirplaneIcon = ({ className = 'w-5 h-5' }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      d="M5.99972 12L3.2688 3.12451C9.88393 5.04617 16.0276 8.07601 21.4855 11.9997C16.0276 15.9235 9.884 18.9535 3.26889 20.8752L5.99972 12ZM5.99972 12L13.5 12"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
 export default function ChatTab({ selected, user }) {
   const [messages, setMessages] = useState([])
   const [newMessage, setNewMessage] = useState('')
@@ -149,29 +183,36 @@ export default function ChatTab({ selected, user }) {
 
       {/* Форма ввода */}
       <div className="p-2 border-t bg-white">
-        <textarea
-          className="w-full border p-2 rounded mb-2 resize-none"
-          rows={2}
-          placeholder="Введите сообщение..."
-          value={newMessage}
-          onChange={e => setNewMessage(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-        <div className="flex items-center space-x-2">
-          <label className="bg-gray-200 p-2 rounded cursor-pointer text-sm">
-            Файл
+        <div className="flex items-end space-x-2">
+          <label className="p-2 cursor-pointer text-gray-500 hover:text-gray-700">
+            <PaperClipIcon />
             <input
               type="file"
               onChange={e => setFile(e.target.files[0])}
               className="hidden"
             />
           </label>
+          <textarea
+            className="flex-1 border rounded-lg p-2 resize-none"
+            rows={2}
+            placeholder="Введите сообщение..."
+            value={newMessage}
+            onChange={e => setNewMessage(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
           <button
             onClick={sendMessage}
             disabled={uploading}
-            className="w-auto bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+            className="p-2 bg-green-500 text-white rounded-full disabled:opacity-50"
           >
-            {uploading ? 'Загрузка...' : 'Отправить'}
+            {uploading ? (
+              <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+              </svg>
+            ) : (
+              <PaperAirplaneIcon />
+            )}
           </button>
         </div>
       </div>

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -3,6 +3,7 @@ import { supabase } from '../supabaseClient';
 import HardwareCard from './HardwareCard';
 import TaskCard from './TaskCard';
 import ChatTab from './ChatTab';
+import WhatsAppIcon from './WhatsAppIcon';
 import { linkifyText } from '../utils/linkify';
 
 // форматирование даты для отображения в русской локали
@@ -37,8 +38,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   const [showDatePicker, setShowDatePicker] = useState(false)
   const [viewingTask, setViewingTask]   = useState(null)
 
-  // --- чаты ---
-  const [chats, setChats]               = useState([])
+  // --- чат ---
+  const [chatMessages, setChatMessages] = useState([])
 
   // загрузка данных при смене объекта
   useEffect(() => {
@@ -48,7 +49,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
     fetchHardware(selected.id)
     fetchTasks(selected.id)
     supabase.from('chat_messages').select('*').eq('object_id', selected.id)
-      .then(({ data }) => setChats(data || []))
+      .then(({ data }) => setChatMessages(data || []))
   }, [selected])
 
   // --- CRUD Описание ---
@@ -193,7 +194,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
         <button className={`tab ${tab==='desc'? 'tab-active':''}`} onClick={()=>setTab('desc')}>📝 Описание</button>
         <button className={`tab ${tab==='hw'? 'tab-active':''}`} onClick={()=>setTab('hw')}>🛠 Железо ({hardware.length})</button>
         <button className={`tab ${tab==='tasks'? 'tab-active':''}`} onClick={()=>setTab('tasks')}>✅ Задачи ({tasks.length})</button>
-        <button className={`tab ${tab==='chats'? 'tab-active':''}`} onClick={()=>setTab('chats')}>💬 Чаты ({chats.length})</button>
+        <button className={`tab ${tab==='chat'? 'tab-active':''}`} onClick={()=>setTab('chat')}><WhatsAppIcon className="inline w-4 h-4 mr-1" /> Чат ({chatMessages.length})</button>
       </div>
 
       <div className="flex-1 overflow-auto p-4">
@@ -402,8 +403,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
           </div>
         )}
 
-        {/* Чаты */}
-        {tab==='chats' && <ChatTab selected={selected} user={user} />}
+        {/* Чат */}
+        {tab==='chat' && <ChatTab selected={selected} user={user} />}
       </div>
     </div>
   )

--- a/src/components/WhatsAppIcon.jsx
+++ b/src/components/WhatsAppIcon.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function WhatsAppIcon({ className = 'w-5 h-5' }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="12" fill="#25D366" />
+      <path
+        d="M17 7H7c-1.1 0-2 .9-2 2v5c0 1.1.9 2 2 2h4l2.5 2.5L15 16h2c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2z"
+        fill="#fff"
+      />
+      <path
+        d="M11 10.5l1 1-1 1"
+        stroke="#25D366"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- rename "Чаты" tab to "Чат" and show WhatsApp-style icon
- redesign chat input with WhatsApp-like send and attachment icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d7c642ec8324880fdc6c47815555