### PR TITLE
Refactor UI with cards, icons, and animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.42.5",
         "daisyui": "^5.0.50",
+        "framer-motion": "^12.23.12",
+        "lucide-react": "^0.536.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.5.2",
@@ -2722,6 +2724,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3603,6 +3632,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3750,6 +3788,21 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -5083,6 +5136,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -11,20 +11,22 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.42.5",
     "daisyui": "^5.0.50",
+    "framer-motion": "^12.23.12",
+    "lucide-react": "^0.536.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.5.2",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.1.2",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.17",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
     "vite": "^4.4.9",
-    "@testing-library/jest-dom": "^6.1.3",
-    "@testing-library/react": "^14.1.2",
-    "jsdom": "^24.0.0",
     "vitest": "^1.6.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import InventoryTabs from './components/InventoryTabs';
 import Auth from './components/Auth';
 import AccountModal from './components/AccountModal';
 import { Toaster, toast } from 'react-hot-toast';
+import { Plus, Trash2 } from 'lucide-react';
 
 export default function App() {
   const [objects, setObjects] = useState([]);
@@ -185,10 +186,10 @@ export default function App() {
                 ☰
               </button>
               <button
-                className="btn btn-primary btn-sm"
+                className="btn btn-primary btn-sm flex items-center gap-1"
                 onClick={() => setIsAddModalOpen(true)}
               >
-                ➕ Добавить
+                <Plus className="w-4 h-4" /> Добавить
               </button>
             </div>
               <div className="flex items-center gap-2">
@@ -238,7 +239,9 @@ export default function App() {
             <div className="modal-box relative w-full max-w-sm">
               <h3 className="font-bold text-lg mb-4">Удалить объект?</h3>
               <div className="modal-action flex space-x-2">
-                <button className="btn btn-error" onClick={confirmDelete}>Удалить</button>
+                <button className="btn btn-error flex items-center gap-1" onClick={confirmDelete}>
+                  <Trash2 className="w-4 h-4" /> Удалить
+                </button>
                 <button className="btn" onClick={() => setDeleteCandidate(null)}>Отмена</button>
               </div>
             </div>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Card({ children, className = '', ...props }) {
+  return (
+    <div className={`rounded-2xl shadow-md p-4 bg-white ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -2,40 +2,8 @@ import React, { useEffect, useState, useRef } from 'react';
 import { supabase } from '../supabaseClient';
 import { v4 as uuidv4 } from 'uuid';
 import { linkifyText } from '../utils/linkify';
-
-const PaperClipIcon = ({ className = 'w-6 h-6' }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <path
-      d="M18.375 12.739L10.682 20.432C8.92462 22.1893 6.07538 22.1893 4.31802 20.432C2.56066 18.6746 2.56066 15.8254 4.31802 14.068L15.2573 3.12868C16.4289 1.95711 18.3283 1.95711 19.4999 3.12868C20.6715 4.30025 20.6715 6.19975 19.4999 7.37132L8.55158 18.3197M8.56066 18.3107C8.55764 18.3137 8.55462 18.3167 8.55158 18.3197M14.2498 8.37865L6.43934 16.1893C5.85355 16.7751 5.85355 17.7249 6.43934 18.3107C7.02211 18.8934 7.9651 18.8964 8.55158 18.3197"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-)
-
-const PaperAirplaneIcon = ({ className = 'w-5 h-5' }) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <path
-      d="M5.99972 12L3.2688 3.12451C9.88393 5.04617 16.0276 8.07601 21.4855 11.9997C16.0276 15.9235 9.884 18.9535 3.26889 20.8752L5.99972 12ZM5.99972 12L13.5 12"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-)
+import { Paperclip, Send } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 export default function ChatTab({ selected, user }) {
   const [messages, setMessages] = useState([])
@@ -144,8 +112,10 @@ export default function ChatTab({ selected, user }) {
           {messages.map(msg => {
             const isOwn = msg.sender === senderName;
             return (
-              <div
+              <motion.div
                 key={msg.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
                 className={`flex mb-2 ${isOwn ? 'justify-end' : 'justify-start'}`}
               >
                 <div
@@ -175,7 +145,7 @@ export default function ChatTab({ selected, user }) {
                     </a>
                   )}
                 </div>
-              </div>
+              </motion.div>
             );
           })}
         <div ref={scrollRef} />
@@ -185,7 +155,7 @@ export default function ChatTab({ selected, user }) {
       <div className="p-2 border-t bg-white">
         <div className="flex items-end space-x-2">
           <label className="p-2 cursor-pointer text-gray-500 hover:text-gray-700">
-            <PaperClipIcon />
+            <Paperclip className="w-6 h-6" />
             <input
               type="file"
               onChange={e => setFile(e.target.files[0])}
@@ -211,7 +181,7 @@ export default function ChatTab({ selected, user }) {
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
               </svg>
             ) : (
-              <PaperAirplaneIcon />
+              <Send className="w-5 h-5" />
             )}
           </button>
         </div>

--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -1,9 +1,11 @@
 // src/components/HardwareCard.jsx
 import React from 'react';
+import Card from './Card';
+import { Pencil, Trash2 } from 'lucide-react';
 
 export default function HardwareCard({ item, onEdit, onDelete }) {
   return (
-    <div className="card bg-base-100 shadow p-4 flex justify-between items-center">
+    <Card className="flex justify-between items-center">
       <div>
         <div className="font-medium text-lg">{item.name}</div>
         <div className="text-sm text-gray-500">{item.location}</div>
@@ -13,9 +15,15 @@ export default function HardwareCard({ item, onEdit, onDelete }) {
         </div>
       </div>
       <div className="flex space-x-2">
-        <button onClick={onEdit}   className="btn btn-sm btn-outline">Изменить</button>
-        <button onClick={onDelete} className="btn btn-sm btn-error">Удалить</button>
+        <button onClick={onEdit} className="btn btn-sm btn-outline flex items-center gap-1">
+          <Pencil className="w-4 h-4" />
+          Изменить
+        </button>
+        <button onClick={onDelete} className="btn btn-sm btn-error flex items-center gap-1">
+          <Trash2 className="w-4 h-4" />
+          Удалить
+        </button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Card from './Card';
+import { Pencil, Trash2 } from 'lucide-react';
 
 export default function InventorySidebar({
   objects,
@@ -10,35 +12,30 @@ export default function InventorySidebar({
   return (
     <nav className="flex flex-col space-y-2">
       {objects.map(o => (
-        <div
-          key={o.id}
-          className="flex items-center justify-between"
-        >
+        <Card key={o.id} className="flex items-center justify-between p-2">
           <button
             onClick={() => onSelect(o)}
-            className={`flex-1 text-left px-3 py-2 rounded ${
-              selected?.id === o.id
-                ? 'bg-blue-100 font-medium'
-                : 'hover:bg-gray-100'
+            className={`flex-1 text-left px-3 py-2 rounded hover:bg-primary/10 ${
+              selected?.id === o.id ? 'border-b-2 border-primary font-medium' : ''
             }`}
           >
             {o.name}
           </button>
           <button
             onClick={() => onEdit(o)}
-            className="ml-2 text-blue-500 hover:text-blue-700"
+            className="ml-2 text-primary hover:text-primary/70"
             title="Редактировать объект"
           >
-            ✎
+            <Pencil className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(o.id)}
             className="ml-2 text-red-500 hover:text-red-700"
             title="Удалить объект"
           >
-            ×
+            <Trash2 className="w-4 h-4" />
           </button>
-        </div>
+        </Card>
       ))}
     </nav>
 );

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -3,7 +3,7 @@ import { supabase } from '../supabaseClient';
 import HardwareCard from './HardwareCard';
 import TaskCard from './TaskCard';
 import ChatTab from './ChatTab';
-import WhatsAppIcon from './WhatsAppIcon';
+import { Plus, MessageSquare } from 'lucide-react';
 import { linkifyText } from '../utils/linkify';
 import { toast } from 'react-hot-toast';
 
@@ -235,11 +235,31 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   return (
     <div className="flex flex-col h-full">
       {/* Вкладки */}
-      <div className="tabs tabs-boxed">
-        <button className={`tab ${tab==='desc'? 'tab-active':''}`} onClick={()=>setTab('desc')}>📝 Описание</button>
-        <button className={`tab ${tab==='hw'? 'tab-active':''}`} onClick={()=>setTab('hw')}>🛠 Железо ({hardware.length})</button>
-        <button className={`tab ${tab==='tasks'? 'tab-active':''}`} onClick={()=>setTab('tasks')}>✅ Задачи ({tasks.length})</button>
-        <button className={`tab ${tab==='chat'? 'tab-active':''}`} onClick={()=>setTab('chat')}><WhatsAppIcon className="inline w-4 h-4 mr-1" /> Чат ({chatMessages.length})</button>
+      <div className="flex mb-4 border-b">
+        <button
+          className={`px-4 py-2 hover:bg-primary/10 ${tab==='desc' ? 'border-b-2 border-primary' : ''}`}
+          onClick={() => setTab('desc')}
+        >
+          Описание
+        </button>
+        <button
+          className={`px-4 py-2 hover:bg-primary/10 ${tab==='hw' ? 'border-b-2 border-primary' : ''}`}
+          onClick={() => setTab('hw')}
+        >
+          Железо ({hardware.length})
+        </button>
+        <button
+          className={`px-4 py-2 hover:bg-primary/10 ${tab==='tasks' ? 'border-b-2 border-primary' : ''}`}
+          onClick={() => setTab('tasks')}
+        >
+          Задачи ({tasks.length})
+        </button>
+        <button
+          className={`px-4 py-2 hover:bg-primary/10 flex items-center gap-1 ${tab==='chat' ? 'border-b-2 border-primary' : ''}`}
+          onClick={() => setTab('chat')}
+        >
+          <MessageSquare className="w-4 h-4" /> Чат ({chatMessages.length})
+        </button>
       </div>
 
       <div className="flex-1 overflow-auto p-4">
@@ -276,10 +296,16 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Оборудование</h3>
-              <button className="btn btn-sm btn-primary" onClick={()=>openHWModal()}>➕ Добавить</button>
+              <button className="btn btn-sm btn-primary flex items-center gap-1" onClick={() => openHWModal()}>
+                <Plus className="w-4 h-4" /> Добавить
+              </button>
             </div>
             {loadingHW ? <p>Загрузка...</p> : (
-              <div className="space-y-2">{hardware.map(h=><HardwareCard key={h.id} item={h} onEdit={()=>openHWModal(h)} onDelete={()=>deleteHardware(h.id)}/>)}</div>
+              <div className="grid gap-2 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                {hardware.map(h => (
+                  <HardwareCard key={h.id} item={h} onEdit={() => openHWModal(h)} onDelete={() => deleteHardware(h.id)} />
+                ))}
+              </div>
             )}
 
             {isHWModalOpen && (
@@ -350,11 +376,21 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Задачи</h3>
-              <button className="btn btn-sm btn-primary" onClick={()=>openTaskModal()}>➕ Добавить задачу</button>
+              <button className="btn btn-sm btn-primary flex items-center gap-1" onClick={() => openTaskModal()}>
+                <Plus className="w-4 h-4" /> Добавить задачу
+              </button>
             </div>
             {loadingTasks ? <p>Загрузка...</p> : (
-              <div className="space-y-2">
-                {tasks.map(t=><TaskCard key={t.id} item={t} onView={()=>openTaskView(t)} onEdit={()=>openTaskModal(t)} onDelete={()=>deleteTask(t.id)}/>)}
+              <div className="grid gap-2 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                {tasks.map(t => (
+                  <TaskCard
+                    key={t.id}
+                    item={t}
+                    onView={() => openTaskView(t)}
+                    onEdit={() => openTaskModal(t)}
+                    onDelete={() => deleteTask(t.id)}
+                  />
+                ))}
               </div>
             )}
 

--- a/src/components/ObjectCard.jsx
+++ b/src/components/ObjectCard.jsx
@@ -1,8 +1,10 @@
+import Card from './Card';
+
 export default function ObjectCard({ item }) {
   return (
-    <div className="p-4 bg-white shadow rounded">
+    <Card>
       <h4 className="font-semibold">{item.name}</h4>
       <p className="text-gray-500">{item.description}</p>
-    </div>
+    </Card>
   )
 }

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Card from './Card';
+import { Pencil, Trash2 } from 'lucide-react';
 
 /**
  * Format date string into locale friendly format.
@@ -13,41 +15,6 @@ function formatDate(dateStr) {
   }
 }
 
-const PencilIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="w-4 h-4"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth={2}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.862 3.487a2.25 2.25 0 0 1 3.182 3.182l-10.5 10.5a1.5 1.5 0 0 1-.684.387l-4.5 1.125a.75.75 0 0 1-.91-.91l1.125-4.5a1.5 1.5 0 0 1 .387-.684l10.5-10.5z"
-    />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 7.125L16.875 4.5" />
-  </svg>
-);
-
-const TrashIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="w-4 h-4"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth={2}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M14.74 9l-.346 9m-4.788-9L9.26 18M6 6h12M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"
-    />
-  </svg>
-);
-
 export default function TaskCard({ item, onEdit, onDelete, onView }) {
   const badgeClass = {
     'запланировано': 'badge-info',
@@ -59,8 +26,8 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
   const dueDate  = item.due_date || item.planned_date || item.plan_date;
 
   return (
-    <div
-      className="flex justify-between items-center p-3 border rounded-lg hover:bg-base-200 transition cursor-pointer"
+    <Card
+      className="flex justify-between items-center cursor-pointer hover:bg-base-200 transition"
       onClick={onView}
     >
       <div className="flex-1">
@@ -83,7 +50,7 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
             onEdit();
           }}
         >
-          <PencilIcon />
+          <Pencil className="w-4 h-4" />
         </button>
         <button
           className="btn btn-sm btn-ghost"
@@ -95,9 +62,9 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
             }
           }}
         >
-          <TrashIcon />
+          <Trash2 className="w-4 h-4" />
         </button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,20 @@ module.exports = {
     "./index.html",
     "./src/**/*.{js,jsx}"
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1d4ed8',
+        secondary: '#64748b',
+        accent: '#f97316',
+      },
+      fontSize: {
+        heading: '1.5rem',
+        body: '1rem',
+        caption: '0.875rem',
+      }
+    }
+  },
   plugins: [
     require('daisyui'),
   ],


### PR DESCRIPTION
## Summary
- add customizable Tailwind theme with primary color palette and font sizes
- introduce reusable Card component and apply it across sidebar, hardware, and tasks
- enhance tabs, actions, and chat with lucide icons and framer-motion animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891e7f5cfd883249f7c0d127242e93b