### PR TITLE
Fix lucide-react resolution during build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  // Pre-bundle lucide-react to avoid resolution issues during the build
+  optimizeDeps: {
+    include: ['lucide-react'],
+  },
   server: {
     host: true,       // bind to 0.0.0.0 (all interfaces)
     port: 5173,       // или любой порт, который вам удобнее


### PR DESCRIPTION
## Summary
- prebundle `lucide-react` to ensure vite resolves icon imports properly

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891f137f6948324b12aad74ab8f473f