### PR TITLE
feat: add assignee column to tasks

### DIFF
--- a/supabase/migrations/20250806082945_add-assignee-column.sql
+++ b/supabase/migrations/20250806082945_add-assignee-column.sql
@@ -1,0 +1,2 @@
+alter table tasks add column assignee text;
+update tasks set assignee = executor where assignee is null;


### PR DESCRIPTION
## Summary
- add migration to introduce `assignee` column in tasks and populate with existing executor values

## Testing
- `npx supabase db push --local` *(fails: dial tcp 127.0.0.1:54322: connect: connection refused)*
- `npx supabase start` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893120afcb8832491bf38907dbad4b0