### PR TITLE
Add unit tests for key inventory app components

### DIFF
--- a/tests/Auth.test.jsx
+++ b/tests/Auth.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/supabaseClient', () => {
+  return {
+    supabase: {
+      auth: {
+        signUp: vi.fn(),
+        signInWithPassword: vi.fn(),
+      },
+    },
+  };
+});
+
+import { supabase } from '../src/supabaseClient';
+import Auth from '../src/components/Auth';
+
+describe('Auth', () => {
+  beforeEach(() => {
+    supabase.auth.signUp.mockReset();
+    supabase.auth.signInWithPassword.mockReset();
+  });
+
+  it('renders login form and toggles to registration', () => {
+    render(<Auth />);
+    expect(screen.getByText('Вход')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Имя пользователя')).toBeNull();
+
+    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'));
+    expect(screen.getByText('Регистрация')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Имя пользователя')).toBeInTheDocument();
+  });
+
+  it('submits login and shows errors', async () => {
+    supabase.auth.signInWithPassword.mockResolvedValue({ error: { message: 'Invalid credentials' } });
+    render(<Auth />);
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Пароль'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Войти' }));
+
+    await screen.findByText('Invalid credentials');
+    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({ email: 'a@b.com', password: '123456' });
+  });
+
+  it('submits registration data', async () => {
+    supabase.auth.signUp.mockResolvedValue({ error: null });
+    render(<Auth />);
+    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'));
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Имя пользователя'), { target: { value: 'tester' } });
+    fireEvent.change(screen.getByPlaceholderText('Пароль'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Зарегистрироваться' }));
+
+    await waitFor(() => expect(supabase.auth.signUp).toHaveBeenCalled());
+    expect(supabase.auth.signUp).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: '123456',
+      options: { data: { username: 'tester' } },
+    });
+  });
+});

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+
+const insertMock = vi.fn();
+
+vi.mock('../src/supabaseClient', () => {
+  const from = vi.fn((table) => {
+    if (table === 'chat_messages') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({ then: (cb) => cb({ data: [] }) })
+          })
+        }),
+        insert: insertMock.mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 1, sender: 'User', content: 'hi', created_at: '2024-01-01' } })
+          })
+        })
+      };
+    }
+    return {};
+  });
+  return {
+    supabase: {
+      from,
+      channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+      removeChannel: vi.fn(),
+      storage: { from: vi.fn(() => ({ upload: vi.fn(), getPublicUrl: vi.fn() })) }
+    }
+  };
+});
+
+import ChatTab from '../src/components/ChatTab';
+
+const selected = { id: 1 };
+const user = { user_metadata: { username: 'User' }, email: 'user@example.com' };
+
+describe('ChatTab', () => {
+  beforeAll(() => {
+    // jsdom doesn't implement scrollIntoView
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+  beforeEach(() => {
+    insertMock.mockClear();
+  });
+
+  it('renders empty state when no messages', () => {
+    render(<ChatTab selected={selected} user={user} />);
+    expect(screen.getByText('Нет сообщений. Начните диалог.')).toBeInTheDocument();
+  });
+
+  it('sends a message and clears input', async () => {
+    render(<ChatTab selected={selected} user={user} />);
+    const textarea = screen.getByPlaceholderText('Введите сообщение...');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    const sendBtn = screen.getByRole('button');
+    fireEvent.click(sendBtn);
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalled());
+    expect(textarea.value).toBe('');
+  });
+
+  it('does not send empty messages', () => {
+    render(<ChatTab selected={selected} user={user} />);
+    const sendBtn = screen.getByRole('button');
+    fireEvent.click(sendBtn);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/supabaseClient', () => {
+  const chain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(), then: vi.fn(cb => cb({ data: [] })) };
+  return {
+    supabase: {
+      from: vi.fn(() => ({ ...chain })),
+      channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+      removeChannel: vi.fn(),
+    }
+  };
+});
+vi.mock('../src/utils/notifications', () => ({ pushNotification: vi.fn() }));
+vi.mock('react-hot-toast', () => ({ toast: { success: vi.fn() } }));
+vi.mock('../src/components/ChatTab', () => ({ default: () => <div data-testid="chat-tab">ChatMock</div> }));
+
+import InventoryTabs from '../src/components/InventoryTabs';
+
+const user = { user_metadata: { username: 'User' }, email: 'user@example.com' };
+
+const renderComponent = (selected) => render(<InventoryTabs selected={selected} onUpdateSelected={() => {}} user={user} />);
+
+describe('InventoryTabs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  it('shows description tab and handles empty description', () => {
+    renderComponent({ id: 1, name: 'Obj', description: '' });
+    expect(screen.getByText('Нет описания')).toBeInTheDocument();
+    expect(screen.getByText('Описание')).toBeInTheDocument();
+  });
+
+  it('switches tabs and renders chat', () => {
+    renderComponent({ id: 1, name: 'Obj', description: '' });
+    fireEvent.click(screen.getByText('Железо (0)'));
+    expect(screen.getByText('Оборудование')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Задачи (0)'));
+    expect(screen.getByText('Задачи')).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Чат \(0\)/));
+    expect(screen.getByTestId('chat-tab')).toBeInTheDocument();
+  });
+
+  it('toggles description edit mode', () => {
+    renderComponent({ id: 1, name: 'Obj', description: 'Initial' });
+    fireEvent.click(screen.getByText('Редактировать'));
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'Changed' } });
+    fireEvent.click(screen.getByText('Отмена'));
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByText('Changed')).toBeInTheDocument();
+  });
+});

--- a/tests/placeholder.test.jsx
+++ b/tests/placeholder.test.jsx
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest'
-
-describe('placeholder', () => {
-  it('runs', () => {
-    expect(true).toBe(true)
-  })
-})


### PR DESCRIPTION
## Summary
- add Auth tests for login, registration, and error handling
- cover ChatTab message workflow and empty state
- ensure InventoryTabs renders tabs, switches views, and handles description edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689317beb6908324bbdbed7d7da965da