### PR TITLE
Handle corrupted localStorage data in InventoryTabs

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -58,11 +58,31 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
     setTab(savedTab || 'desc')
     const savedHWForm = typeof localStorage !== 'undefined' ? localStorage.getItem(HW_FORM_KEY(selected.id)) : null
     const savedHWOpen = typeof localStorage !== 'undefined' ? localStorage.getItem(HW_MODAL_KEY(selected.id)) === 'true' : false
-    setHWForm(savedHWForm ? JSON.parse(savedHWForm) : defaultHWForm)
+    let parsedHWForm = defaultHWForm
+    if (savedHWForm) {
+      try {
+        parsedHWForm = JSON.parse(savedHWForm)
+      } catch {
+        if (typeof localStorage !== 'undefined') {
+          localStorage.removeItem(HW_FORM_KEY(selected.id))
+        }
+      }
+    }
+    setHWForm(parsedHWForm)
     setIsHWModalOpen(savedHWOpen)
     const savedTaskForm = typeof localStorage !== 'undefined' ? localStorage.getItem(TASK_FORM_KEY(selected.id)) : null
     const savedTaskOpen = typeof localStorage !== 'undefined' ? localStorage.getItem(TASK_MODAL_KEY(selected.id)) === 'true' : false
-    setTaskForm(savedTaskForm ? JSON.parse(savedTaskForm) : defaultTaskForm)
+    let parsedTaskForm = defaultTaskForm
+    if (savedTaskForm) {
+      try {
+        parsedTaskForm = JSON.parse(savedTaskForm)
+      } catch {
+        if (typeof localStorage !== 'undefined') {
+          localStorage.removeItem(TASK_FORM_KEY(selected.id))
+        }
+      }
+    }
+    setTaskForm(parsedTaskForm)
     setIsTaskModalOpen(savedTaskOpen)
     setDescription(selected.description || '')
     fetchHardware(selected.id)

--- a/tests/inventoryTabsLocalStorage.test.jsx
+++ b/tests/inventoryTabsLocalStorage.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import InventoryTabs from '../src/components/InventoryTabs'
+
+vi.mock('../src/supabaseClient', () => {
+  const createQuery = () => {
+    const query = {}
+    query.select = vi.fn(() => query)
+    query.eq = vi.fn(() => query)
+    query.order = vi.fn(() => Promise.resolve({ data: [] }))
+    query.then = vi.fn((resolve) => Promise.resolve({ data: [] }).then(resolve))
+    return query
+  }
+  return {
+    supabase: {
+      from: vi.fn(() => createQuery()),
+      channel: vi.fn(() => ({
+        on: vi.fn().mockReturnThis(),
+        subscribe: vi.fn(() => ({})),
+      })),
+      removeChannel: vi.fn(),
+    },
+  }
+})
+
+describe('InventoryTabs localStorage recovery', () => {
+  const objectId = 1
+  const selected = { id: objectId, name: 'Test', description: '' }
+  const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' }
+  const hwFormKey = `hwForm_${objectId}`
+  const hwModalKey = `hwModal_${objectId}`
+  const taskFormKey = `taskForm_${objectId}`
+  const taskModalKey = `taskModal_${objectId}`
+  const tabKey = `tab_${objectId}`
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  const defaultHWForm = { name: '', location: '', purchase_status: 'не оплачен', install_status: 'не установлен' }
+  const defaultTaskForm = { title: '', status: 'запланировано', assignee: '', due_date: '', notes: '' }
+
+  it('resets forms and clears storage on malformed JSON', async () => {
+    localStorage.setItem(hwFormKey, '{bad json')
+    localStorage.setItem(hwModalKey, 'true')
+    localStorage.setItem(taskFormKey, '{bad json')
+    localStorage.setItem(taskModalKey, 'true')
+    localStorage.setItem(tabKey, 'hw')
+
+    render(<InventoryTabs selected={selected} onUpdateSelected={() => {}} user={user} />)
+
+    await waitFor(() => {
+      expect(localStorage.getItem(hwFormKey)).toBe(JSON.stringify(defaultHWForm))
+    })
+    const hwNameInput = await screen.findByPlaceholderText('Например, keenetic giga')
+    expect(hwNameInput).toHaveValue('')
+    expect(screen.getByText('Не оплачен').selected).toBe(true)
+    expect(screen.getByText('Не установлен').selected).toBe(true)
+
+    fireEvent.click(screen.getByText(/Задачи/))
+
+    await waitFor(() => {
+      expect(localStorage.getItem(taskFormKey)).toBe(JSON.stringify(defaultTaskForm))
+    })
+    expect(screen.getByText('Запланировано').selected).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Safely parse hardware and task form state from localStorage, clearing malformed data and falling back to defaults
- Add tests verifying forms recover from corrupted localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689317bd85f0832489218b2af948d8b4