### PR TITLE
Handle chat file upload errors

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { supabase } from '../supabaseClient';
+import { toast } from 'react-hot-toast';
 import { v4 as uuidv4 } from 'uuid';
 import { linkifyText } from '../utils/linkify';
 import { PaperClipIcon, PaperAirplaneIcon } from '@heroicons/react/24/outline';
@@ -65,15 +66,22 @@ export default function ChatTab({ selected, user }) {
     if (file) {
       setUploading(true)
       const filePath = `${selected.id}/${uuidv4()}_${file.name}`
-      const { error: upErr } = await supabase.storage
-        .from('chat-files')
-        .upload(filePath, file)
-      if (upErr) console.error('Upload error:', upErr)
-      else {
+      try {
+        const { error: upErr } = await supabase.storage
+          .from('chat-files')
+          .upload(filePath, file)
+
+        if (upErr) throw upErr
+
         const { data } = supabase.storage
           .from('chat-files')
           .getPublicUrl(filePath)
         fileUrl = data.publicUrl
+      } catch (err) {
+        console.error('Upload error:', err)
+        toast.error('Ошибка загрузки файла')
+        setUploading(false)
+        return
       }
       setUploading(false)
     }

--- a/tests/chatTab.test.jsx
+++ b/tests/chatTab.test.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatTab from '../src/components/ChatTab.jsx';
+import { toast } from 'react-hot-toast';
+
+const { uploadMock, insertMock, supabaseMock, toastErrorMock } = vi.hoisted(() => {
+  const uploadMock = vi.fn();
+  const getPublicUrlMock = vi.fn(() => ({ data: { publicUrl: 'public-url' } }));
+  const singleMock = vi.fn().mockResolvedValue({ data: { id: '1' }, error: null });
+  const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }));
+  const insertMock = vi.fn(() => ({ select: selectAfterInsertMock }));
+  const selectMock = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      order: vi.fn(() => ({
+        then: vi.fn(cb => {
+          cb({ data: [], error: null });
+          return Promise.resolve({ data: [], error: null });
+        })
+      }))
+    }))
+  }));
+  const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock }));
+  const channelMock = vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() }));
+  const removeChannelMock = vi.fn();
+  const supabaseMock = {
+    from: fromMock,
+    storage: { from: vi.fn(() => ({ upload: uploadMock, getPublicUrl: getPublicUrlMock })) },
+    channel: channelMock,
+    removeChannel: removeChannelMock,
+  };
+  const toastErrorMock = vi.fn();
+  return { uploadMock, insertMock, supabaseMock, toastErrorMock };
+});
+
+vi.mock('../src/supabaseClient.js', () => ({
+  supabase: supabaseMock,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: { error: toastErrorMock },
+}));
+
+const user = { user_metadata: { username: 'Tester' }, email: 'test@example.com' };
+const selected = { id: 'object1' };
+
+describe('ChatTab file upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom doesn't implement scrollIntoView
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('sends message when upload succeeds', async () => {
+    uploadMock.mockResolvedValue({ data: {}, error: null });
+
+    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
+    const textarea = getByPlaceholderText('Введите сообщение...');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    const fileInput = container.querySelector('input[type="file"]');
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    const sendButton = container.querySelector('button');
+    await fireEvent.click(sendButton);
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+    expect(insertMock).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows error and blocks message on upload failure', async () => {
+    uploadMock.mockResolvedValue({ data: null, error: new Error('fail') });
+
+    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
+    const textarea = getByPlaceholderText('Введите сообщение...');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    const fileInput = container.querySelector('input[type="file"]');
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    const sendButton = container.querySelector('button');
+    await fireEvent.click(sendButton);
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+    expect(toastErrorMock).toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- show toast and stop sending when chat file upload fails
- add tests for successful and failed file uploads in chat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893179af0a4832492f6e6d6d9c81721