### PR TITLE
fix: avoid assignee column error

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -269,7 +269,6 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
       object_id: selected.id,
       title: taskForm.title,
       status: taskForm.status,
-      assignee: taskForm.assignee || null,
       executor: taskForm.assignee || null,
       due_date: taskForm.due_date || null,
       planned_date: taskForm.due_date || null,

--- a/tests/saveTaskExecutor.test.jsx
+++ b/tests/saveTaskExecutor.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const insertSpy = vi.fn(() => ({
+  select: vi.fn(() => ({
+    single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null }))
+  }))
+}));
+
+vi.mock('../src/supabaseClient', () => {
+  const createQuery = () => ({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn(() => Promise.resolve({ data: [] })),
+    then: vi.fn(cb => cb({ data: [] })),
+    insert: insertSpy,
+    update: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null })) })) }))
+  });
+  return {
+    supabase: {
+      from: vi.fn(() => createQuery()),
+      channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+      removeChannel: vi.fn(),
+    }
+  };
+});
+
+import InventoryTabs from '../src/components/InventoryTabs';
+
+const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' };
+
+describe('saveTask uses executor column', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    insertSpy.mockClear();
+  });
+
+  it('sends executor and omits assignee', async () => {
+    render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
+    fireEvent.click(screen.getByText('Задачи (0)'));
+    fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: 'Test task' } });
+    fireEvent.change(inputs[1], { target: { value: 'Bob' } });
+    fireEvent.click(screen.getByText('Сохранить'));
+    await waitFor(() => expect(insertSpy).toHaveBeenCalled());
+    const payload = insertSpy.mock.calls[0][0][0];
+    expect(payload.executor).toBe('Bob');
+    expect(payload.assignee).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- remove `assignee` from task payloads to avoid missing column error
- add test ensuring tasks save using `executor` only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68931dec6e5c8324ae64f2190c4c3563