### PR TITLE
refactor: use executor field in task forms

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -249,7 +249,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
       setTaskForm({
         title: item.title,
         status: item.status,
-        executor: item.executor || item.assignee || '',
+        executor: item.executor || '',
         due_date: item.due_date || item.planned_date || item.plan_date || '',
         notes: item.notes || ''
       })
@@ -544,8 +544,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
                   <button className="btn btn-sm btn-circle absolute right-2 top-2" onClick={()=>setViewingTask(null)}>✕</button>
                   <h3 className="font-bold text-lg mb-4">{viewingTask.title}</h3>
                   <div className="space-y-2">
-                    {(viewingTask.executor || viewingTask.assignee) && (
-                      <p><strong>Исполнитель:</strong> {viewingTask.executor || viewingTask.assignee}</p>
+                    {viewingTask.executor && (
+                      <p><strong>Исполнитель:</strong> {viewingTask.executor}</p>
                     )}
                     {(viewingTask.due_date || viewingTask.planned_date || viewingTask.plan_date) && (
                       <p><strong>Дата:</strong> {formatDate(viewingTask.due_date || viewingTask.planned_date || viewingTask.plan_date)}</p>

--- a/tests/saveTaskExecutor.test.jsx
+++ b/tests/saveTaskExecutor.test.jsx
@@ -36,7 +36,7 @@ describe('saveTask uses executor column', () => {
     insertSpy.mockClear();
   });
 
-  it('sends executor and omits assignee and due_date', async () => {
+  it('sends executor and omits due_date', async () => {
     render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
     fireEvent.click(screen.getByText('Задачи (0)'));
     fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
@@ -47,7 +47,6 @@ describe('saveTask uses executor column', () => {
     await waitFor(() => expect(insertSpy).toHaveBeenCalled());
     const payload = insertSpy.mock.calls[0][0][0];
     expect(payload.executor).toBe('Bob');
-    expect(payload.assignee).toBeUndefined();
     expect(payload.due_date).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- remove legacy assignee references in InventoryTabs
- update task modal and view to rely on executor
- adjust saveTask unit test for executor field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689327956afc8324879ad6a42f448443