### PR TITLE
feat: replace executor field with assignee

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -45,7 +45,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
   const [loadingTasks, setLoadingTasks] = useState(false)
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false)
   const [editingTask, setEditingTask]   = useState(null)
-  const defaultTaskForm = { title: '', status: 'запланировано', executor: '', due_date: '', notes: '' }
+  const defaultTaskForm = { title: '', status: 'запланировано', assignee: '', due_date: '', notes: '' }
   const [taskForm, setTaskForm]         = useState(defaultTaskForm)
   const [showDatePicker, setShowDatePicker] = useState(false)
   const [viewingTask, setViewingTask]   = useState(null)
@@ -79,6 +79,10 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
     if (savedTaskForm) {
       try {
         parsedTaskForm = JSON.parse(savedTaskForm)
+        if (parsedTaskForm.executor && !parsedTaskForm.assignee) {
+          parsedTaskForm.assignee = parsedTaskForm.executor
+          delete parsedTaskForm.executor
+        }
       } catch {
         if (typeof localStorage !== 'undefined') {
           localStorage.removeItem(TASK_FORM_KEY(selected.id))
@@ -249,7 +253,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
       setTaskForm({
         title: item.title,
         status: item.status,
-        executor: item.executor || '',
+        assignee: item.assignee || item.executor || '',
         due_date: item.due_date || item.planned_date || item.plan_date || '',
         notes: item.notes || ''
       })
@@ -269,7 +273,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
       object_id: selected.id,
       title: taskForm.title,
       status: taskForm.status,
-      executor: taskForm.executor || null,
+      assignee: taskForm.assignee || null,
       planned_date: taskForm.due_date || null,
       plan_date: taskForm.due_date || null,
       notes: taskForm.notes || null
@@ -491,8 +495,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
                       <input
                         type="text"
                         className="input input-bordered w-full"
-                        value={taskForm.executor}
-                        onChange={e=>setTaskForm(f=>({...f,executor:e.target.value}))}
+                        value={taskForm.assignee}
+                        onChange={e=>setTaskForm(f=>({...f,assignee:e.target.value}))}
                       />
                     </div>
                     <div className="form-control">
@@ -544,8 +548,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user }) {
                   <button className="btn btn-sm btn-circle absolute right-2 top-2" onClick={()=>setViewingTask(null)}>✕</button>
                   <h3 className="font-bold text-lg mb-4">{viewingTask.title}</h3>
                   <div className="space-y-2">
-                    {viewingTask.executor && (
-                      <p><strong>Исполнитель:</strong> {viewingTask.executor}</p>
+                    {(viewingTask.assignee || viewingTask.executor) && (
+                      <p><strong>Исполнитель:</strong> {viewingTask.assignee || viewingTask.executor}</p>
                     )}
                     {(viewingTask.due_date || viewingTask.planned_date || viewingTask.plan_date) && (
                       <p><strong>Дата:</strong> {formatDate(viewingTask.due_date || viewingTask.planned_date || viewingTask.plan_date)}</p>

--- a/supabase/migrations/20250806082945_add-assignee-column.sql
+++ b/supabase/migrations/20250806082945_add-assignee-column.sql
@@ -1,2 +1,16 @@
-alter table tasks add column assignee text;
-update tasks set assignee = executor where assignee is null;
+alter table tasks
+  add column if not exists assignee text;
+
+-- migrate existing values from executor to assignee if the old column exists
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_name = 'tasks' and column_name = 'executor'
+  ) then
+    update tasks set assignee = executor where assignee is null;
+  end if;
+end $$;
+
+-- drop legacy column
+alter table tasks drop column if exists executor;

--- a/tests/inventoryTabsLocalStorage.test.jsx
+++ b/tests/inventoryTabsLocalStorage.test.jsx
@@ -39,7 +39,7 @@ describe('InventoryTabs localStorage recovery', () => {
   })
 
   const defaultHWForm = { name: '', location: '', purchase_status: 'не оплачен', install_status: 'не установлен' }
-  const defaultTaskForm = { title: '', status: 'запланировано', executor: '', due_date: '', notes: '' }
+  const defaultTaskForm = { title: '', status: 'запланировано', assignee: '', due_date: '', notes: '' }
 
   it('resets forms and clears storage on malformed JSON', async () => {
     localStorage.setItem(hwFormKey, '{bad json')

--- a/tests/saveTaskExecutor.test.jsx
+++ b/tests/saveTaskExecutor.test.jsx
@@ -30,13 +30,13 @@ import InventoryTabs from '../src/components/InventoryTabs';
 
 const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' };
 
-describe('saveTask uses executor column', () => {
+describe('saveTask uses assignee column', () => {
   beforeEach(() => {
     localStorage.clear();
     insertSpy.mockClear();
   });
 
-  it('sends executor and omits due_date', async () => {
+  it('sends assignee and omits due_date', async () => {
     render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
     fireEvent.click(screen.getByText('Задачи (0)'));
     fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
@@ -46,7 +46,7 @@ describe('saveTask uses executor column', () => {
     fireEvent.click(screen.getByText('Сохранить'));
     await waitFor(() => expect(insertSpy).toHaveBeenCalled());
     const payload = insertSpy.mock.calls[0][0][0];
-    expect(payload.executor).toBe('Bob');
+    expect(payload.assignee).toBe('Bob');
     expect(payload.due_date).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- migrate tasks table to new `assignee` field and drop legacy `executor`
- use `assignee` throughout InventoryTabs, mapping any old executor values
- update tests to expect `assignee`

## Testing
- `npm test`
- `yes | npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689330cf9a788324aef961b911b2005b