### PR TITLE
Cleanup ChatTab attachment preview

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -155,62 +155,10 @@ export default function ChatTab({ selected, user }) {
                       {linkifyText(msg.content)}
                     </div>
                   )}
-codex/add-file-buttons-for-non-image-files
-                  {msg.file_url && (() => {
-                    const url = msg.file_url;
-                    const isImage = /\.(png|jpe?g|gif|bmp|webp)$/i.test(url);
-                    const isVideo = /\.(mp4|webm|ogg)$/i.test(url);
-                    if (isImage) {
-                      return (
-                        <img
-                          src={url}
-                          alt="attachment"
-                          className="max-w-full h-auto mt-1"
-                        />
-                      );
-                    }
-                    if (isVideo) {
-                      return (
-                        <video
-                          src={url}
-                          controls
-                          className="max-w-full h-auto mt-1"
-                        />
-                      );
-                    }
-                    const fileName = url.split('/').pop();
-                    return (
-                      <div className="mt-1">
-                        <div className="break-words mb-1">{fileName}</div>
-                        <div className="flex space-x-2">
-                          <a
-                            href={url}
-                            download
-                            className="text-blue-500 underline"
-                          >
-                            Скачать
-                          </a>
-                          <a
-                            href={url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-500 underline"
-                          >
-                            Открыть
-                          </a>
-                        </div>
-                      </div>
-                    );
-                  })()}
 
                   {msg.file_url && (
-                  codex/add-video-file-handling-in-attachmentpreview
-                    <AttachmentPreview url={msg.file_url} />
-
                     <AttachmentPreview url={msg.file_url} onImageClick={setModalImage} />
-main
                   )}
-main
                 </div>
               </motion.div>
             );


### PR DESCRIPTION
## Summary
- remove leftover codex and conflict markers
- simplify attachment preview to a single `AttachmentPreview` call

## Testing
- `npm test` *(fails: Transform failed with 1 error: Unexpected "in")*

------
https://chatgpt.com/codex/tasks/task_e_68935bddab1c8324a3a699c612380680