### PR TITLE
Сброс выбранного файла в чате после отправки

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -14,6 +14,7 @@ export default function ChatTab({ selected, user }) {
   const [uploading, setUploading] = useState(false)
   const [modalImage, setModalImage] = useState(null)
   const scrollRef = useRef(null)
+  const fileInputRef = useRef(null)
   const senderName = user.user_metadata?.username || user.email
 
   // Загрузка и подписка на новые сообщения
@@ -95,6 +96,8 @@ export default function ChatTab({ selected, user }) {
         console.error('Upload error:', err)
         toast.error('Ошибка загрузки файла')
         setUploading(false)
+        setFile(null)
+        if (fileInputRef.current) fileInputRef.current.value = ''
         return
       }
       setUploading(false)
@@ -113,6 +116,7 @@ export default function ChatTab({ selected, user }) {
 
     setNewMessage('')
     setFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
   const handleKeyDown = e => {
@@ -172,6 +176,7 @@ export default function ChatTab({ selected, user }) {
             <PaperClipIcon className="w-6 h-6" />
             <input
               type="file"
+              ref={fileInputRef}
               onChange={e => setFile(e.target.files[0])}
               className="hidden"
             />

--- a/tests/chatTab.test.jsx
+++ b/tests/chatTab.test.jsx
@@ -67,6 +67,7 @@ describe('ChatTab file upload', () => {
     await waitFor(() => expect(uploadMock).toHaveBeenCalled());
     expect(insertMock).toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
+    expect(fileInput.value).toBe('');
   });
 
   it('shows error and blocks message on upload failure', async () => {
@@ -85,5 +86,6 @@ describe('ChatTab file upload', () => {
     await waitFor(() => expect(uploadMock).toHaveBeenCalled());
     expect(toastErrorMock).toHaveBeenCalled();
     expect(insertMock).not.toHaveBeenCalled();
+    expect(fileInput.value).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- очистка инпута выбора файла после отправки сообщения
- сброс файла при ошибке загрузки
- обновлены тесты ChatTab

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6894387064e0832492e981feee83c075