### PR TITLE
Добавить тест рендера App

### DIFF
--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/supabaseClient.js', () => {
+  const channelMock = { on: vi.fn().mockReturnThis(), subscribe: vi.fn() };
+  return {
+    supabase: {
+      auth: {
+        getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+        onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      },
+      channel: vi.fn(() => channelMock),
+      removeChannel: vi.fn(),
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      })),
+    },
+  };
+});
+
+vi.mock('../src/utils/notifications', () => ({
+  requestNotificationPermission: vi.fn(),
+  pushNotification: vi.fn(),
+  playTaskSound: vi.fn(),
+  playMessageSound: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  Toaster: () => null,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import App from '../src/App';
+
+describe('App', () => {
+  it('renders App without crashing', async () => {
+    render(<App />);
+    expect(await screen.findByText('Вход')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- добавлен тест рендера `App` без запросов к внешним сервисам

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68944c85dd848324b1fb0ce2151b6d01