### PR TITLE
Добавить хуки для работы с Supabase

### DIFF
--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { useAccount } from '../hooks/useAccount';
 import { toast } from 'react-hot-toast';
 
 export default function AccountModal({ user, onClose, onUpdated }) {
   const [username, setUsername] = useState(user.user_metadata?.username || '');
   const [saving, setSaving] = useState(false);
 
+  const { updateProfile } = useAccount();
+
   async function save() {
     setSaving(true);
-    const { data, error } = await supabase.auth.updateUser({ data: { username } });
+    const { data, error } = await updateProfile({ username });
     setSaving(false);
     if (error) {
       toast.error('Ошибка обновления: ' + error.message);

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
 
 export default function Auth() {
   const [email, setEmail] = useState('')
@@ -8,14 +8,16 @@ export default function Auth() {
   const [isRegister, setIsRegister] = useState(false)
   const [error, setError] = useState(null)
 
+  const { signUp, signIn } = useAuth()
+
   async function handleSubmit(e) {
     e.preventDefault()
     setError(null)
     let res
     if (isRegister) {
-      res = await supabase.auth.signUp({ email, password, options: { data: { username } } })
+      res = await signUp(email, password, username)
     } else {
-      res = await supabase.auth.signInWithPassword({ email, password })
+      res = await signIn(email, password)
     }
     if (res.error) setError(res.error.message)
   }

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from '../supabaseClient';
 import HardwareCard from './HardwareCard';
 import TaskCard from './TaskCard';
 import ChatTab from './ChatTab';
@@ -7,6 +6,10 @@ import { PlusIcon, ChatBubbleOvalLeftIcon } from '@heroicons/react/24/outline';
 import { linkifyText } from '../utils/linkify';
 import { toast } from 'react-hot-toast';
 import ConfirmModal from './ConfirmModal';
+import { useHardware } from '../hooks/useHardware';
+import { useTasks } from '../hooks/useTasks';
+import { useChatMessages } from '../hooks/useChatMessages';
+import { useObjects } from '../hooks/useObjects';
 
 const TAB_KEY = objectId => `tab_${objectId}`;
 const HW_MODAL_KEY = objectId => `hwModal_${objectId}`;
@@ -53,6 +56,11 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   // --- чат ---
   const [chatMessages, setChatMessages] = useState([])
 
+  const { fetchHardware: fetchHardwareApi, insertHardware, updateHardware, deleteHardware } = useHardware()
+  const { fetchTasks: fetchTasksApi, insertTask, updateTask, deleteTask, subscribeToTasks } = useTasks()
+  const { fetchMessages, subscribeToMessages } = useChatMessages()
+  const { updateObject } = useObjects()
+
   // загрузка данных при смене объекта и восстановление состояния UI
   useEffect(() => {
     if (!selected) return
@@ -93,8 +101,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
     setDescription(selected.description || '')
     fetchHardware(selected.id)
     fetchTasks(selected.id)
-    supabase.from('chat_messages').select('*').eq('object_id', selected.id)
-      .then(({ data }) => setChatMessages(data || []))
+    fetchMessages(selected.id).then(({ data }) => setChatMessages(data || []))
   }, [selected])
 
   useEffect(() => {
@@ -135,46 +142,29 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   // realtime обновление задач и чата
   useEffect(() => {
     if (!selected) return
-    const taskChannel = supabase
-      .channel(`tasks_object_${selected.id}`)
-      .on('postgres_changes', {
-        event: 'INSERT',
-        schema: 'public',
-        table: 'tasks',
-        filter: `object_id=eq.${selected.id}`
-      }, payload => {
-        setTasks(prev => {
-          if (prev.some(t => t.id === payload.new.id)) return prev
-          return [...prev, payload.new]
-        })
+    const unsubscribeTasks = subscribeToTasks(selected.id, payload => {
+      setTasks(prev => {
+        if (prev.some(t => t.id === payload.new.id)) return prev
+        return [...prev, payload.new]
       })
-      .subscribe()
+    })
 
-    const chatChannel = supabase
-      .channel(`chat_messages_object_${selected.id}_tabs`)
-      .on('postgres_changes', {
-        event: 'INSERT',
-        schema: 'public',
-        table: 'chat_messages',
-        filter: `object_id=eq.${selected.id}`
-      }, payload => {
-        setChatMessages(prev => {
-          if (prev.some(m => m.id === payload.new.id)) return prev
-          return [...prev, payload.new]
-        })
+    const unsubscribeChat = subscribeToMessages(selected.id, payload => {
+      setChatMessages(prev => {
+        if (prev.some(m => m.id === payload.new.id)) return prev
+        return [...prev, payload.new]
       })
-      .subscribe()
+    })
 
     return () => {
-      supabase.removeChannel(taskChannel)
-      supabase.removeChannel(chatChannel)
+      unsubscribeTasks()
+      unsubscribeChat()
     }
   }, [selected])
 
   // --- CRUD Описание ---
   async function saveDescription() {
-    const { data, error } = await supabase
-      .from('objects').update({ description }).eq('id', selected.id).select()
+    const { data, error } = await updateObject(selected.id, { description })
     if (!error) {
       onUpdateSelected({ ...selected, description: data[0].description })
       setIsEditingDesc(false)
@@ -184,9 +174,8 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   // --- CRUD Оборудование ---
   async function fetchHardware(objectId) {
     setLoadingHW(true)
-    const { data, error } = await supabase
-      .from('hardware').select('*').eq('object_id', objectId).order('created_at')
-    if (!error) setHardware(data)
+    const { data, error } = await fetchHardwareApi(objectId)
+    if (!error) setHardware(data || [])
     setLoadingHW(false)
   }
   function openHWModal(item = null) {
@@ -208,9 +197,9 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
     const payload = { object_id: selected.id, ...hwForm }
     let res
     if (editingHW) {
-      res = await supabase.from('hardware').update(payload).eq('id', editingHW.id).select().single()
+      res = await updateHardware(editingHW.id, payload)
     } else {
-      res = await supabase.from('hardware').insert([payload]).select().single()
+      res = await insertHardware(payload)
     }
     if (res.error) return toast.error('Ошибка оборудования: ' + res.error.message)
     const rec = res.data
@@ -224,7 +213,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   }
   async function confirmDeleteHardware() {
     const id = hwDeleteId
-    const { error } = await supabase.from('hardware').delete().eq('id', id)
+    const { error } = await deleteHardware(id)
     if (error) return toast.error('Ошибка удаления')
     setHardware(prev => prev.filter(h => h.id !== id))
     setHwDeleteId(null)
@@ -233,8 +222,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   // --- CRUD Задачи ---
   async function fetchTasks(objectId) {
     setLoadingTasks(true)
-    const { data, error } = await supabase
-      .from('tasks').select('*').eq('object_id', objectId).order('created_at')
+    const { data, error } = await fetchTasksApi(objectId)
     if (!error) {
       setTasks(data || [])
     }
@@ -279,9 +267,9 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
     }
     let res
     if (editingTask) {
-      res = await supabase.from('tasks').update(payload).eq('id', editingTask.id).select().single()
+      res = await updateTask(editingTask.id, payload)
     } else {
-      res = await supabase.from('tasks').insert([payload]).select().single()
+      res = await insertTask(payload)
     }
     if (res.error) return toast.error('Ошибка задач: ' + res.error.message)
     const rec = res.data
@@ -300,7 +288,7 @@ export default function InventoryTabs({ selected, onUpdateSelected, user, onTabC
   }
   async function confirmDeleteTask() {
     const id = taskDeleteId
-    const { error } = await supabase.from('tasks').delete().eq('id', id)
+    const { error } = await deleteTask(id)
     if (error) return toast.error('Ошибка удаления')
     setTasks(prev => prev.filter(t => t.id !== id))
     setTaskDeleteId(null)

--- a/src/hooks/useAccount.js
+++ b/src/hooks/useAccount.js
@@ -1,0 +1,6 @@
+import { supabase } from '../supabaseClient';
+
+export function useAccount() {
+  const updateProfile = data => supabase.auth.updateUser({ data });
+  return { updateProfile };
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,11 @@
+import { supabase } from '../supabaseClient';
+
+export function useAuth() {
+  const getSession = () => supabase.auth.getSession();
+  const onAuthStateChange = callback => supabase.auth.onAuthStateChange(callback);
+  const signUp = (email, password, username) =>
+    supabase.auth.signUp({ email, password, options: { data: { username } } });
+  const signIn = (email, password) => supabase.auth.signInWithPassword({ email, password });
+  const signOut = () => supabase.auth.signOut();
+  return { getSession, onAuthStateChange, signUp, signIn, signOut };
+}

--- a/src/hooks/useChatMessages.js
+++ b/src/hooks/useChatMessages.js
@@ -1,0 +1,54 @@
+import { supabase } from '../supabaseClient';
+import { v4 as uuidv4 } from 'uuid';
+
+export function useChatMessages() {
+  const fetchMessages = objectId =>
+    supabase
+      .from('chat_messages')
+      .select('*')
+      .eq('object_id', objectId)
+      .order('created_at', { ascending: true });
+
+  async function sendMessage({ objectId, sender, content, file }) {
+    let fileUrl = null;
+    if (file) {
+      const filePath = `${objectId}/${uuidv4()}_${file.name}`;
+      const { error: uploadError } = await supabase.storage
+        .from('chat-files')
+        .upload(filePath, file);
+      if (uploadError) return { error: uploadError };
+      const { data } = supabase.storage
+        .from('chat-files')
+        .getPublicUrl(filePath);
+      fileUrl = data.publicUrl;
+    }
+    return supabase
+      .from('chat_messages')
+      .insert([{ object_id: objectId, sender, content, file_url: fileUrl }])
+      .select()
+      .single();
+  }
+
+  const subscribeToMessages = (objectId, handler) => {
+    const channel = supabase
+      .channel(`chat_messages_object_${objectId}`)
+      .on('postgres_changes', {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'chat_messages',
+        filter: `object_id=eq.${objectId}`
+      }, handler)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  };
+
+  const subscribeToAllMessages = handler => {
+    const channel = supabase
+      .channel('chat_all')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'chat_messages' }, handler)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  };
+
+  return { fetchMessages, sendMessage, subscribeToMessages, subscribeToAllMessages };
+}

--- a/src/hooks/useHardware.js
+++ b/src/hooks/useHardware.js
@@ -1,0 +1,19 @@
+import { supabase } from '../supabaseClient';
+
+export function useHardware() {
+  const fetchHardware = objectId =>
+    supabase
+      .from('hardware')
+      .select('*')
+      .eq('object_id', objectId)
+      .order('created_at');
+
+  const insertHardware = data => supabase.from('hardware').insert([data]).select().single();
+
+  const updateHardware = (id, data) =>
+    supabase.from('hardware').update(data).eq('id', id).select().single();
+
+  const deleteHardware = id => supabase.from('hardware').delete().eq('id', id);
+
+  return { fetchHardware, insertHardware, updateHardware, deleteHardware };
+}

--- a/src/hooks/useObjects.js
+++ b/src/hooks/useObjects.js
@@ -1,0 +1,28 @@
+import { supabase } from '../supabaseClient';
+
+export function useObjects() {
+  const fetchObjects = () =>
+    supabase
+      .from('objects')
+      .select('*')
+      .order('created_at', { ascending: true });
+
+  const insertObject = name =>
+    supabase
+      .from('objects')
+      .insert([{ name, description: '' }])
+      .select()
+      .single();
+
+  const updateObject = (id, data) =>
+    supabase
+      .from('objects')
+      .update(data)
+      .eq('id', id)
+      .select()
+      .single();
+
+  const deleteObject = id => supabase.from('objects').delete().eq('id', id);
+
+  return { fetchObjects, insertObject, updateObject, deleteObject };
+}

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,0 +1,40 @@
+import { supabase } from '../supabaseClient';
+
+export function useTasks() {
+  const fetchTasks = objectId =>
+    supabase
+      .from('tasks')
+      .select('*')
+      .eq('object_id', objectId)
+      .order('created_at');
+
+  const insertTask = data => supabase.from('tasks').insert([data]).select().single();
+
+  const updateTask = (id, data) =>
+    supabase.from('tasks').update(data).eq('id', id).select().single();
+
+  const deleteTask = id => supabase.from('tasks').delete().eq('id', id);
+
+  const subscribeToTasks = (objectId, handler) => {
+    const channel = supabase
+      .channel(`tasks_object_${objectId}`)
+      .on('postgres_changes', {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'tasks',
+        filter: `object_id=eq.${objectId}`
+      }, handler)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  };
+
+  const subscribeToAllTasks = handler => {
+    const channel = supabase
+      .channel('tasks_all')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'tasks' }, handler)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  };
+
+  return { fetchTasks, insertTask, updateTask, deleteTask, subscribeToTasks, subscribeToAllTasks };
+}


### PR DESCRIPTION
## Summary
- вынесена работа с Supabase в хуки для авторизации, профиля, сообщений, задач, оборудования и объектов
- компоненты переведены на использование новых хуков вместо прямых вызовов Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a12530148324a24a3332119c5199