### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build -- --dry-run


### PR DESCRIPTION
## Summary
- add CI workflow for lint, test and build checks

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a14d1220832483bc5665f066773e