### PR TITLE
chore: enable rls policies

### DIFF
--- a/supabase/migrations/enable-rls-and-policies.sql
+++ b/supabase/migrations/enable-rls-and-policies.sql
@@ -1,0 +1,21 @@
+-- Enable Row Level Security and add policies for authenticated users
+
+-- Objects table
+alter table objects enable row level security;
+create policy "allow_authenticated" on objects
+  for all using (auth.role() = 'authenticated');
+
+-- Hardware table
+alter table hardware enable row level security;
+create policy "allow_authenticated" on hardware
+  for all using (auth.role() = 'authenticated');
+
+-- Tasks table
+alter table tasks enable row level security;
+create policy "allow_authenticated" on tasks
+  for all using (auth.role() = 'authenticated');
+
+-- Chat messages table
+alter table chat_messages enable row level security;
+create policy "allow_authenticated" on chat_messages
+  for all using (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary
- enable row level security across objects, hardware, tasks, and chat_messages
- add allow_authenticated policy for all tables

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a1609858832488f18fb20f266d14