### PR TITLE
Обновить импорты тестов и алиас '@'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,14 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.32.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.1.2",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.17",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.20",
+        "globals": "^16.3.0",
         "husky": "^9.1.7",
         "jsdom": "^24.0.0",
         "lint-staged": "^16.1.4",
@@ -841,6 +845,222 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
@@ -848,6 +1068,77 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">= 16 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1453,6 +1744,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
@@ -1681,6 +1980,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -1702,6 +2012,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1768,6 +2096,14 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -1995,6 +2331,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-css": {
@@ -2232,6 +2579,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -2433,6 +2788,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2684,6 +3047,221 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
+      "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.32.0",
+        "@eslint/plugin-kit": "^0.3.4",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
+      "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2692,6 +3270,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -2725,6 +3314,14 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -2753,6 +3350,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2760,6 +3373,20 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -2773,6 +3400,47 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3012,6 +3680,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/goober": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
@@ -3189,6 +3870,46 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -3599,6 +4320,20 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "24.1.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
@@ -3689,6 +4424,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3699,6 +4458,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -3848,12 +4633,37 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -4206,6 +5016,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4361,6 +5179,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -4377,11 +5214,73 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -4394,6 +5293,17 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -4671,6 +5581,17 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -4896,6 +5817,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/restore-cursor": {
@@ -5398,6 +6330,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
@@ -5602,6 +6548,20 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -5662,6 +6622,17 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {
@@ -7005,6 +7976,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,14 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.32.0",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.1.2",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.17",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.3.0",
     "husky": "^9.1.7",
     "jsdom": "^24.0.0",
     "lint-staged": "^16.1.4",

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -1,14 +1,16 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 
-vi.mock('../src/supabaseClient.js', () => {
+vi.mock("@/supabaseClient.js", () => {
   const channelMock = { on: vi.fn().mockReturnThis(), subscribe: vi.fn() };
   return {
     supabase: {
       auth: {
         getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
-        onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+        onAuthStateChange: vi.fn(() => ({
+          data: { subscription: { unsubscribe: vi.fn() } },
+        })),
       },
       channel: vi.fn(() => channelMock),
       removeChannel: vi.fn(),
@@ -20,23 +22,23 @@ vi.mock('../src/supabaseClient.js', () => {
   };
 });
 
-vi.mock('../src/utils/notifications', () => ({
+vi.mock("@/utils/notifications", () => ({
   requestNotificationPermission: vi.fn(),
   pushNotification: vi.fn(),
   playTaskSound: vi.fn(),
   playMessageSound: vi.fn(),
 }));
 
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   Toaster: () => null,
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-import App from '../src/App';
+import App from "@/App";
 
-describe('App', () => {
-  it('renders App without crashing', async () => {
+describe("App", () => {
+  it("renders App without crashing", async () => {
     render(<App />);
-    expect(await screen.findByText('Вход')).toBeInTheDocument();
+    expect(await screen.findByText("Вход")).toBeInTheDocument();
   });
 });

--- a/tests/Auth.test.jsx
+++ b/tests/Auth.test.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock('../src/supabaseClient.js', () => {
+vi.mock("@/supabaseClient.js", () => {
   return {
     supabase: {
       auth: {
@@ -13,50 +13,65 @@ vi.mock('../src/supabaseClient.js', () => {
   };
 });
 
-import { supabase } from '../src/supabaseClient.js';
-import Auth from '../src/components/Auth';
+import { supabase } from "@/supabaseClient.js";
+import Auth from "@/components/Auth";
 
-describe('Auth', () => {
+describe("Auth", () => {
   beforeEach(() => {
     supabase.auth.signUp.mockReset();
     supabase.auth.signInWithPassword.mockReset();
   });
 
-  it('renders login form and toggles to registration', () => {
+  it("renders login form and toggles to registration", () => {
     render(<Auth />);
-    expect(screen.getByText('Вход')).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText('Имя пользователя')).toBeNull();
+    expect(screen.getByText("Вход")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Имя пользователя")).toBeNull();
 
-    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'));
-    expect(screen.getByText('Регистрация')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Имя пользователя')).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Нет аккаунта? Регистрация"));
+    expect(screen.getByText("Регистрация")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Имя пользователя")).toBeInTheDocument();
   });
 
-  it('submits login and shows errors', async () => {
-    supabase.auth.signInWithPassword.mockResolvedValue({ error: { message: 'Invalid credentials' } });
+  it("submits login and shows errors", async () => {
+    supabase.auth.signInWithPassword.mockResolvedValue({
+      error: { message: "Invalid credentials" },
+    });
     render(<Auth />);
-    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
-    fireEvent.change(screen.getByPlaceholderText('Пароль'), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Войти' }));
+    fireEvent.change(screen.getByPlaceholderText("Email"), {
+      target: { value: "a@b.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Пароль"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Войти" }));
 
-    await screen.findByText('Invalid credentials');
-    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({ email: 'a@b.com', password: '123456' });
+    await screen.findByText("Invalid credentials");
+    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: "a@b.com",
+      password: "123456",
+    });
   });
 
-  it('submits registration data', async () => {
+  it("submits registration data", async () => {
     supabase.auth.signUp.mockResolvedValue({ error: null });
     render(<Auth />);
-    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'));
-    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } });
-    fireEvent.change(screen.getByPlaceholderText('Имя пользователя'), { target: { value: 'tester' } });
-    fireEvent.change(screen.getByPlaceholderText('Пароль'), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Зарегистрироваться' }));
+    fireEvent.click(screen.getByText("Нет аккаунта? Регистрация"));
+    fireEvent.change(screen.getByPlaceholderText("Email"), {
+      target: { value: "a@b.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Имя пользователя"), {
+      target: { value: "tester" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Пароль"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Зарегистрироваться" }));
 
     await waitFor(() => expect(supabase.auth.signUp).toHaveBeenCalled());
     expect(supabase.auth.signUp).toHaveBeenCalledWith({
-      email: 'a@b.com',
-      password: '123456',
-      options: { data: { username: 'tester' } },
+      email: "a@b.com",
+      password: "123456",
+      options: { data: { username: "tester" } },
     });
   });
 });

--- a/tests/Card.test.jsx
+++ b/tests/Card.test.jsx
@@ -1,17 +1,17 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import Card from '../src/components/Card.jsx';
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Card from "@/components/Card.jsx";
 
-describe('Card', () => {
-  it('renders content and applies extra class', () => {
+describe("Card", () => {
+  it("renders content and applies extra class", () => {
     const { getByText, container } = render(
       <Card className="extra">
         <span>контент</span>
-      </Card>
+      </Card>,
     );
 
-    expect(getByText('контент')).toBeInTheDocument();
-    expect(container.firstChild).toHaveClass('extra');
+    expect(getByText("контент")).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass("extra");
   });
 });

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -1,56 +1,76 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock('../src/supabaseClient.js', () => {
-  const chain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(), then: vi.fn(cb => cb({ data: [] })) };
+vi.mock("@/supabaseClient.js", () => {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    then: vi.fn((cb) => cb({ data: [] })),
+  };
   return {
     supabase: {
       from: vi.fn(() => ({ ...chain })),
-      channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+      channel: vi.fn(() => ({
+        on: vi.fn().mockReturnThis(),
+        subscribe: vi.fn(),
+      })),
       removeChannel: vi.fn(),
-    }
+    },
   };
 });
-vi.mock('../src/utils/notifications', () => ({ pushNotification: vi.fn(), playTaskSound: vi.fn(), playMessageSound: vi.fn() }));
-vi.mock('react-hot-toast', () => ({ toast: { success: vi.fn() } }));
-vi.mock('../src/components/ChatTab', () => ({ default: () => <div data-testid="chat-tab">ChatMock</div> }));
+vi.mock("@/utils/notifications", () => ({
+  pushNotification: vi.fn(),
+  playTaskSound: vi.fn(),
+  playMessageSound: vi.fn(),
+}));
+vi.mock("react-hot-toast", () => ({ toast: { success: vi.fn() } }));
+vi.mock("@/components/ChatTab", () => ({
+  default: () => <div data-testid="chat-tab">ChatMock</div>,
+}));
 
-import InventoryTabs from '../src/components/InventoryTabs';
+import InventoryTabs from "@/components/InventoryTabs";
 
-const user = { user_metadata: { username: 'User' }, email: 'user@example.com' };
+const user = { user_metadata: { username: "User" }, email: "user@example.com" };
 
-const renderComponent = (selected) => render(
-  <InventoryTabs selected={selected} onUpdateSelected={() => {}} user={user} onTabChange={() => {}} />
-);
+const renderComponent = (selected) =>
+  render(
+    <InventoryTabs
+      selected={selected}
+      onUpdateSelected={() => {}}
+      user={user}
+      onTabChange={() => {}}
+    />,
+  );
 
-describe('InventoryTabs', () => {
+describe("InventoryTabs", () => {
   beforeEach(() => {
     localStorage.clear();
   });
-  it('shows description tab and handles empty description', () => {
-    renderComponent({ id: 1, name: 'Obj', description: '' });
-    expect(screen.getByText('Нет описания')).toBeInTheDocument();
-    expect(screen.getByText('Описание')).toBeInTheDocument();
+  it("shows description tab and handles empty description", () => {
+    renderComponent({ id: 1, name: "Obj", description: "" });
+    expect(screen.getByText("Нет описания")).toBeInTheDocument();
+    expect(screen.getByText("Описание")).toBeInTheDocument();
   });
 
-  it('switches tabs and renders chat', () => {
-    renderComponent({ id: 1, name: 'Obj', description: '' });
-    fireEvent.click(screen.getByText('Железо (0)'));
-    expect(screen.getByText('Оборудование')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Задачи (0)'));
-    expect(screen.getByText('Задачи')).toBeInTheDocument();
+  it("switches tabs and renders chat", () => {
+    renderComponent({ id: 1, name: "Obj", description: "" });
+    fireEvent.click(screen.getByText("Железо (0)"));
+    expect(screen.getByText("Оборудование")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Задачи (0)"));
+    expect(screen.getByText("Задачи")).toBeInTheDocument();
     fireEvent.click(screen.getByText(/Чат \(0\)/));
-    expect(screen.getByTestId('chat-tab')).toBeInTheDocument();
+    expect(screen.getByTestId("chat-tab")).toBeInTheDocument();
   });
 
-  it('toggles description edit mode', () => {
-    renderComponent({ id: 1, name: 'Obj', description: 'Initial' });
-    fireEvent.click(screen.getByText('Редактировать'));
-    const textarea = screen.getByRole('textbox');
-    fireEvent.change(textarea, { target: { value: 'Changed' } });
-    fireEvent.click(screen.getByText('Отмена'));
-    expect(screen.queryByRole('textbox')).toBeNull();
-    expect(screen.getByText('Changed')).toBeInTheDocument();
+  it("toggles description edit mode", () => {
+    renderComponent({ id: 1, name: "Obj", description: "Initial" });
+    fireEvent.click(screen.getByText("Редактировать"));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Changed" } });
+    fireEvent.click(screen.getByText("Отмена"));
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByText("Changed")).toBeInTheDocument();
   });
 });

--- a/tests/chatTab.test.jsx
+++ b/tests/chatTab.test.jsx
@@ -1,91 +1,112 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import ChatTab from '../src/components/ChatTab.jsx';
-import { toast } from 'react-hot-toast';
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ChatTab from "@/components/ChatTab.jsx";
+import { toast } from "react-hot-toast";
 
-const { uploadMock, insertMock, supabaseMock, toastErrorMock } = vi.hoisted(() => {
-  const uploadMock = vi.fn();
-  const getPublicUrlMock = vi.fn(() => ({ data: { publicUrl: 'public-url' } }));
-  const singleMock = vi.fn().mockResolvedValue({ data: { id: '1' }, error: null });
-  const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }));
-  const insertMock = vi.fn(() => ({ select: selectAfterInsertMock }));
-  const selectMock = vi.fn(() => ({
-    eq: vi.fn(() => ({
-      order: vi.fn(() => ({
-        then: vi.fn(cb => {
-          cb({ data: [], error: null });
-          return Promise.resolve({ data: [], error: null });
-        })
-      }))
-    }))
-  }));
-  const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock }));
-  const channelMock = vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() }));
-  const removeChannelMock = vi.fn();
-  const supabaseMock = {
-    from: fromMock,
-    storage: { from: vi.fn(() => ({ upload: uploadMock, getPublicUrl: getPublicUrlMock })) },
-    channel: channelMock,
-    removeChannel: removeChannelMock,
-  };
-  const toastErrorMock = vi.fn();
-  return { uploadMock, insertMock, supabaseMock, toastErrorMock };
-});
+const { uploadMock, insertMock, supabaseMock, toastErrorMock } = vi.hoisted(
+  () => {
+    const uploadMock = vi.fn();
+    const getPublicUrlMock = vi.fn(() => ({
+      data: { publicUrl: "public-url" },
+    }));
+    const singleMock = vi
+      .fn()
+      .mockResolvedValue({ data: { id: "1" }, error: null });
+    const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectAfterInsertMock }));
+    const selectMock = vi.fn(() => ({
+      eq: vi.fn(() => ({
+        order: vi.fn(() => ({
+          then: vi.fn((cb) => {
+            cb({ data: [], error: null });
+            return Promise.resolve({ data: [], error: null });
+          }),
+        })),
+      })),
+    }));
+    const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock }));
+    const channelMock = vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    }));
+    const removeChannelMock = vi.fn();
+    const supabaseMock = {
+      from: fromMock,
+      storage: {
+        from: vi.fn(() => ({
+          upload: uploadMock,
+          getPublicUrl: getPublicUrlMock,
+        })),
+      },
+      channel: channelMock,
+      removeChannel: removeChannelMock,
+    };
+    const toastErrorMock = vi.fn();
+    return { uploadMock, insertMock, supabaseMock, toastErrorMock };
+  },
+);
 
-vi.mock('../src/supabaseClient.js', () => ({
+vi.mock("@/supabaseClient.js", () => ({
   supabase: supabaseMock,
 }));
 
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   toast: { error: toastErrorMock },
 }));
 
-const user = { user_metadata: { username: 'Tester' }, email: 'test@example.com' };
-const selected = { id: 'object1' };
+const user = {
+  user_metadata: { username: "Tester" },
+  email: "test@example.com",
+};
+const selected = { id: "object1" };
 
-describe('ChatTab file upload', () => {
+describe("ChatTab file upload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // jsdom doesn't implement scrollIntoView
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
   });
 
-  it('sends message when upload succeeds', async () => {
+  it("sends message when upload succeeds", async () => {
     uploadMock.mockResolvedValue({ data: {}, error: null });
 
-    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
-    const textarea = getByPlaceholderText('Введите сообщение...');
-    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    const { container, getByPlaceholderText } = render(
+      <ChatTab selected={selected} user={user} />,
+    );
+    const textarea = getByPlaceholderText("Введите сообщение...");
+    fireEvent.change(textarea, { target: { value: "Hello" } });
     const fileInput = container.querySelector('input[type="file"]');
-    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    const sendButton = container.querySelector('button');
+    const sendButton = container.querySelector("button");
     await fireEvent.click(sendButton);
 
     await waitFor(() => expect(uploadMock).toHaveBeenCalled());
     expect(insertMock).toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
-    expect(fileInput.value).toBe('');
+    expect(fileInput.value).toBe("");
   });
 
-  it('shows error and blocks message on upload failure', async () => {
-    uploadMock.mockResolvedValue({ data: null, error: new Error('fail') });
+  it("shows error and blocks message on upload failure", async () => {
+    uploadMock.mockResolvedValue({ data: null, error: new Error("fail") });
 
-    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
-    const textarea = getByPlaceholderText('Введите сообщение...');
-    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    const { container, getByPlaceholderText } = render(
+      <ChatTab selected={selected} user={user} />,
+    );
+    const textarea = getByPlaceholderText("Введите сообщение...");
+    fireEvent.change(textarea, { target: { value: "Hello" } });
     const fileInput = container.querySelector('input[type="file"]');
-    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    const sendButton = container.querySelector('button');
+    const sendButton = container.querySelector("button");
     await fireEvent.click(sendButton);
 
     await waitFor(() => expect(uploadMock).toHaveBeenCalled());
     expect(toastErrorMock).toHaveBeenCalled();
     expect(insertMock).not.toHaveBeenCalled();
-    expect(fileInput.value).toBe('');
+    expect(fileInput.value).toBe("");
   });
 });

--- a/tests/confirmModal.test.jsx
+++ b/tests/confirmModal.test.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import ConfirmModal from '../src/components/ConfirmModal';
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ConfirmModal from "@/components/ConfirmModal";
 
-describe('ConfirmModal', () => {
-  it('calls callbacks on actions', () => {
+describe("ConfirmModal", () => {
+  it("calls callbacks on actions", () => {
     const onConfirm = vi.fn();
     const onCancel = vi.fn();
     render(
@@ -14,11 +14,11 @@ describe('ConfirmModal', () => {
         confirmLabel="Да"
         onConfirm={onConfirm}
         onCancel={onCancel}
-      />
+      />,
     );
-    fireEvent.click(screen.getByText('Да'));
+    fireEvent.click(screen.getByText("Да"));
     expect(onConfirm).toHaveBeenCalled();
-    fireEvent.click(screen.getByText('Отмена'));
+    fireEvent.click(screen.getByText("Отмена"));
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/tests/inventoryTabsLocalStorage.test.jsx
+++ b/tests/inventoryTabsLocalStorage.test.jsx
@@ -1,17 +1,19 @@
-import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import InventoryTabs from '../src/components/InventoryTabs'
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import InventoryTabs from "@/components/InventoryTabs";
 
-vi.mock('../src/supabaseClient.js', () => {
+vi.mock("@/supabaseClient.js", () => {
   const createQuery = () => {
-    const query = {}
-    query.select = vi.fn(() => query)
-    query.eq = vi.fn(() => query)
-    query.order = vi.fn(() => Promise.resolve({ data: [] }))
-    query.then = vi.fn((resolve) => Promise.resolve({ data: [] }).then(resolve))
-    return query
-  }
+    const query = {};
+    query.select = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.order = vi.fn(() => Promise.resolve({ data: [] }));
+    query.then = vi.fn((resolve) =>
+      Promise.resolve({ data: [] }).then(resolve),
+    );
+    return query;
+  };
   return {
     supabase: {
       from: vi.fn(() => createQuery()),
@@ -21,48 +23,75 @@ vi.mock('../src/supabaseClient.js', () => {
       })),
       removeChannel: vi.fn(),
     },
-  }
-})
+  };
+});
 
-describe('InventoryTabs localStorage recovery', () => {
-  const objectId = 1
-  const selected = { id: objectId, name: 'Test', description: '' }
-  const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' }
-  const hwFormKey = `hwForm_${objectId}`
-  const hwModalKey = `hwModal_${objectId}`
-  const taskFormKey = `taskForm_${objectId}`
-  const taskModalKey = `taskModal_${objectId}`
-  const tabKey = `tab_${objectId}`
+describe("InventoryTabs localStorage recovery", () => {
+  const objectId = 1;
+  const selected = { id: objectId, name: "Test", description: "" };
+  const user = {
+    user_metadata: { username: "tester" },
+    email: "test@example.com",
+  };
+  const hwFormKey = `hwForm_${objectId}`;
+  const hwModalKey = `hwModal_${objectId}`;
+  const taskFormKey = `taskForm_${objectId}`;
+  const taskModalKey = `taskModal_${objectId}`;
+  const tabKey = `tab_${objectId}`;
 
   beforeEach(() => {
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
 
-  const defaultHWForm = { name: '', location: '', purchase_status: 'не оплачен', install_status: 'не установлен' }
-  const defaultTaskForm = { title: '', status: 'запланировано', assignee: '', due_date: '', notes: '' }
+  const defaultHWForm = {
+    name: "",
+    location: "",
+    purchase_status: "не оплачен",
+    install_status: "не установлен",
+  };
+  const defaultTaskForm = {
+    title: "",
+    status: "запланировано",
+    assignee: "",
+    due_date: "",
+    notes: "",
+  };
 
-  it('resets forms and clears storage on malformed JSON', async () => {
-    localStorage.setItem(hwFormKey, '{bad json')
-    localStorage.setItem(hwModalKey, 'true')
-    localStorage.setItem(taskFormKey, '{bad json')
-    localStorage.setItem(taskModalKey, 'true')
-    localStorage.setItem(tabKey, 'hw')
+  it("resets forms and clears storage on malformed JSON", async () => {
+    localStorage.setItem(hwFormKey, "{bad json");
+    localStorage.setItem(hwModalKey, "true");
+    localStorage.setItem(taskFormKey, "{bad json");
+    localStorage.setItem(taskModalKey, "true");
+    localStorage.setItem(tabKey, "hw");
 
-    render(<InventoryTabs selected={selected} onUpdateSelected={() => {}} user={user} onTabChange={() => {}} />)
+    render(
+      <InventoryTabs
+        selected={selected}
+        onUpdateSelected={() => {}}
+        user={user}
+        onTabChange={() => {}}
+      />,
+    );
 
     await waitFor(() => {
-      expect(localStorage.getItem(hwFormKey)).toBe(JSON.stringify(defaultHWForm))
-    })
-    const hwNameInput = await screen.findByPlaceholderText('Например, keenetic giga')
-    expect(hwNameInput).toHaveValue('')
-    expect(screen.getByText('Не оплачен').selected).toBe(true)
-    expect(screen.getByText('Не установлен').selected).toBe(true)
+      expect(localStorage.getItem(hwFormKey)).toBe(
+        JSON.stringify(defaultHWForm),
+      );
+    });
+    const hwNameInput = await screen.findByPlaceholderText(
+      "Например, keenetic giga",
+    );
+    expect(hwNameInput).toHaveValue("");
+    expect(screen.getByText("Не оплачен").selected).toBe(true);
+    expect(screen.getByText("Не установлен").selected).toBe(true);
 
-    fireEvent.click(screen.getByText(/Задачи/))
+    fireEvent.click(screen.getByText(/Задачи/));
 
     await waitFor(() => {
-      expect(localStorage.getItem(taskFormKey)).toBe(JSON.stringify(defaultTaskForm))
-    })
-    expect(screen.getByText('Запланировано').selected).toBe(true)
-  })
-})
+      expect(localStorage.getItem(taskFormKey)).toBe(
+        JSON.stringify(defaultTaskForm),
+      );
+    });
+    expect(screen.getByText("Запланировано").selected).toBe(true);
+  });
+});

--- a/tests/linkify.test.jsx
+++ b/tests/linkify.test.jsx
@@ -1,28 +1,32 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { linkifyText } from '../src/utils/linkify';
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { linkifyText } from "@/utils/linkify";
 
 // Tests to ensure malicious HTML is not executed and links are created safely
 
-describe('linkifyText', () => {
-  it('does not execute malicious HTML and renders it as text', () => {
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
-    const { container } = render(<div>{linkifyText('<img src=x onerror=alert(1)>')}</div>);
-    expect(container.querySelector('img')).toBeNull();
+describe("linkifyText", () => {
+  it("does not execute malicious HTML and renders it as text", () => {
+    const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const { container } = render(
+      <div>{linkifyText("<img src=x onerror=alert(1)>")}</div>,
+    );
+    expect(container.querySelector("img")).toBeNull();
     expect(alertMock).not.toHaveBeenCalled();
     alertMock.mockRestore();
   });
 
-  it('creates clickable links for URLs', () => {
+  it("creates clickable links for URLs", () => {
     const { container } = render(
-      <div>{linkifyText('Visit https://example.com and www.test.com now')}</div>
+      <div>
+        {linkifyText("Visit https://example.com and www.test.com now")}
+      </div>,
     );
-    const links = container.querySelectorAll('a');
+    const links = container.querySelectorAll("a");
     expect(links).toHaveLength(2);
-    expect(links[0].getAttribute('href')).toBe('https://example.com');
-    expect(links[0].textContent).toBe('https://example.com');
-    expect(links[1].getAttribute('href')).toBe('http://www.test.com');
-    expect(links[1].textContent).toBe('www.test.com');
+    expect(links[0].getAttribute("href")).toBe("https://example.com");
+    expect(links[0].textContent).toBe("https://example.com");
+    expect(links[1].getAttribute("href")).toBe("http://www.test.com");
+    expect(links[1].textContent).toBe("www.test.com");
   });
 });

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -1,15 +1,18 @@
-import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
-import { requestNotificationPermission, pushNotification } from '../src/utils/notifications.js';
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import {
+  requestNotificationPermission,
+  pushNotification,
+} from "@/utils/notifications.js";
 
-describe('notifications utils', () => {
+describe("notifications utils", () => {
   let originalNotification;
 
   beforeEach(() => {
-    originalNotification = global.Notification;
+    originalNotification = globalThis.Notification;
   });
 
   afterEach(() => {
-    global.Notification = originalNotification;
+    globalThis.Notification = originalNotification;
     if (originalNotification) {
       window.Notification = originalNotification;
     } else {
@@ -18,30 +21,30 @@ describe('notifications utils', () => {
     vi.restoreAllMocks();
   });
 
-  it('requests permission when status is default', () => {
+  it("requests permission when status is default", () => {
     const requestPermission = vi.fn();
-    const mockNotification = { permission: 'default', requestPermission };
-    global.Notification = mockNotification;
+    const mockNotification = { permission: "default", requestPermission };
+    globalThis.Notification = mockNotification;
     window.Notification = mockNotification;
     requestNotificationPermission();
     expect(requestPermission).toHaveBeenCalled();
   });
 
-  it('shows notification when permission granted', () => {
+  it("shows notification when permission granted", () => {
     const constructor = vi.fn();
-    constructor.permission = 'granted';
-    global.Notification = constructor;
+    constructor.permission = "granted";
+    globalThis.Notification = constructor;
     window.Notification = constructor;
-    pushNotification('Title', 'Body');
-    expect(constructor).toHaveBeenCalledWith('Title', { body: 'Body' });
+    pushNotification("Title", "Body");
+    expect(constructor).toHaveBeenCalledWith("Title", { body: "Body" });
   });
 
-  it('does not show notification when permission denied', () => {
+  it("does not show notification when permission denied", () => {
     const constructor = vi.fn();
-    constructor.permission = 'denied';
-    global.Notification = constructor;
+    constructor.permission = "denied";
+    globalThis.Notification = constructor;
     window.Notification = constructor;
-    pushNotification('Title', 'Body');
+    pushNotification("Title", "Body");
     expect(constructor).not.toHaveBeenCalled();
   });
 });

--- a/tests/saveTaskExecutor.test.jsx
+++ b/tests/saveTaskExecutor.test.jsx
@@ -1,53 +1,68 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const insertSpy = vi.fn(() => ({
   select: vi.fn(() => ({
-    single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null }))
-  }))
+    single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null })),
+  })),
 }));
 
-vi.mock('../src/supabaseClient.js', () => {
+vi.mock("@/supabaseClient.js", () => {
   const createQuery = () => ({
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     order: vi.fn(() => Promise.resolve({ data: [] })),
-    then: vi.fn(cb => cb({ data: [] })),
+    then: vi.fn((cb) => cb({ data: [] })),
     insert: insertSpy,
-    update: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null })) })) }))
+    update: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(() => Promise.resolve({ data: { id: 1 }, error: null })),
+      })),
+    })),
   });
   return {
     supabase: {
       from: vi.fn(() => createQuery()),
-      channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+      channel: vi.fn(() => ({
+        on: vi.fn().mockReturnThis(),
+        subscribe: vi.fn(),
+      })),
       removeChannel: vi.fn(),
-    }
+    },
   };
 });
 
-import InventoryTabs from '../src/components/InventoryTabs';
+import InventoryTabs from "@/components/InventoryTabs";
 
-const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' };
+const user = {
+  user_metadata: { username: "tester" },
+  email: "test@example.com",
+};
 
-describe('saveTask uses assignee column', () => {
+describe("saveTask uses assignee column", () => {
   beforeEach(() => {
     localStorage.clear();
     insertSpy.mockClear();
   });
 
-  it('sends assignee and omits due_date', async () => {
-    render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
-    fireEvent.click(screen.getByText('Задачи (0)'));
-    fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
-    const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0], { target: { value: 'Test task' } });
-    fireEvent.change(inputs[1], { target: { value: 'Bob' } });
-    fireEvent.click(screen.getByText('Сохранить'));
+  it("sends assignee and omits due_date", async () => {
+    render(
+      <InventoryTabs
+        selected={{ id: 1, name: "Obj", description: "" }}
+        onUpdateSelected={() => {}}
+        user={user}
+      />,
+    );
+    fireEvent.click(screen.getByText("Задачи (0)"));
+    fireEvent.click(screen.getByRole("button", { name: /Добавить задачу/ }));
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "Test task" } });
+    fireEvent.change(inputs[1], { target: { value: "Bob" } });
+    fireEvent.click(screen.getByText("Сохранить"));
     await waitFor(() => expect(insertSpy).toHaveBeenCalled());
     const payload = insertSpy.mock.calls[0][0][0];
-    expect(payload.assignee).toBe('Bob');
+    expect(payload.assignee).toBe("Bob");
     expect(payload.due_date).toBeUndefined();
   });
 });
-

--- a/tests/taskForm.test.jsx
+++ b/tests/taskForm.test.jsx
@@ -1,70 +1,90 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { insertMock, supabaseMock, toastErrorMock } = vi.hoisted(() => {
   const insertMock = vi.fn((records) => ({
     select: vi.fn(() => ({
-      single: vi.fn(() => Promise.resolve({ data: { id: 1, ...records[0] }, error: null }))
-    }))
+      single: vi.fn(() =>
+        Promise.resolve({ data: { id: 1, ...records[0] }, error: null }),
+      ),
+    })),
   }));
   const chain = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     order: vi.fn(() => Promise.resolve({ data: [] })),
-    then: vi.fn(cb => cb({ data: [] })),
+    then: vi.fn((cb) => cb({ data: [] })),
     insert: insertMock,
   };
   const supabaseMock = {
     from: vi.fn(() => ({ ...chain })),
-    channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    })),
     removeChannel: vi.fn(),
   };
   const toastErrorMock = vi.fn();
   return { insertMock, supabaseMock, toastErrorMock };
 });
 
-vi.mock('../src/supabaseClient.js', () => ({
+vi.mock("@/supabaseClient.js", () => ({
   supabase: supabaseMock,
 }));
 
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   toast: { error: toastErrorMock, success: vi.fn() },
 }));
 
-import InventoryTabs from '../src/components/InventoryTabs';
+import InventoryTabs from "@/components/InventoryTabs";
 
-const user = { user_metadata: { username: 'tester' }, email: 'test@example.com' };
+const user = {
+  user_metadata: { username: "tester" },
+  email: "test@example.com",
+};
 
-describe('task form validation', () => {
+describe("task form validation", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
   });
 
-  it('shows error and blocks empty task', async () => {
-    render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
-    fireEvent.click(screen.getByText('Задачи (0)'));
-    fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
-    fireEvent.click(screen.getByText('Сохранить'));
+  it("shows error and blocks empty task", async () => {
+    render(
+      <InventoryTabs
+        selected={{ id: 1, name: "Obj", description: "" }}
+        onUpdateSelected={() => {}}
+        user={user}
+      />,
+    );
+    fireEvent.click(screen.getByText("Задачи (0)"));
+    fireEvent.click(screen.getByRole("button", { name: /Добавить задачу/ }));
+    fireEvent.click(screen.getByText("Сохранить"));
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
     expect(insertMock).not.toHaveBeenCalled();
   });
 
-  it('saves filled task', async () => {
-    render(<InventoryTabs selected={{ id: 1, name: 'Obj', description: '' }} onUpdateSelected={() => {}} user={user} />);
-    fireEvent.click(screen.getByText('Задачи (0)'));
-    fireEvent.click(screen.getByRole('button', { name: /Добавить задачу/ }));
-    const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0], { target: { value: 'Task title' } });
-    fireEvent.change(inputs[1], { target: { value: 'Bob' } });
-    fireEvent.click(screen.getByText('Сохранить'));
+  it("saves filled task", async () => {
+    render(
+      <InventoryTabs
+        selected={{ id: 1, name: "Obj", description: "" }}
+        onUpdateSelected={() => {}}
+        user={user}
+      />,
+    );
+    fireEvent.click(screen.getByText("Задачи (0)"));
+    fireEvent.click(screen.getByRole("button", { name: /Добавить задачу/ }));
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "Task title" } });
+    fireEvent.change(inputs[1], { target: { value: "Bob" } });
+    fireEvent.click(screen.getByText("Сохранить"));
     await waitFor(() => expect(insertMock).toHaveBeenCalled());
     expect(insertMock.mock.calls[0][0][0]).toEqual({
       object_id: 1,
-      title: 'Task title',
-      status: 'запланировано',
-      assignee: 'Bob',
+      title: "Task title",
+      status: "запланировано",
+      assignee: "Bob",
       planned_date: null,
       plan_date: null,
       notes: null,

--- a/tests/taskcard.test.jsx
+++ b/tests/taskcard.test.jsx
@@ -1,16 +1,21 @@
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import TaskCard from '../src/components/TaskCard';
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import TaskCard from "@/components/TaskCard";
 
-describe('TaskCard', () => {
-  it('calls onDelete when delete button clicked', () => {
+describe("TaskCard", () => {
+  it("calls onDelete when delete button clicked", () => {
     const onDelete = vi.fn();
-    const dummy = { id: 1, title: 't', status: 'запланировано' };
+    const dummy = { id: 1, title: "t", status: "запланировано" };
     const { getByTitle } = render(
-      <TaskCard item={dummy} onEdit={() => {}} onDelete={onDelete} onView={() => {}} />
+      <TaskCard
+        item={dummy}
+        onEdit={() => {}}
+        onDelete={onDelete}
+        onView={() => {}}
+      />,
     );
-    fireEvent.click(getByTitle('Удалить'));
+    fireEvent.click(getByTitle("Удалить"));
     expect(onDelete).toHaveBeenCalled();
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,18 +1,27 @@
 // vite.config.js
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   // No additional optimizeDeps entries required after switching icon libraries
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   server: {
-    host: true,       // bind to 0.0.0.0 (all interfaces)
-    port: 5173,       // или любой порт, который вам удобнее
+    host: true, // bind to 0.0.0.0 (all interfaces)
+    port: 5173, // или любой порт, который вам удобнее
     strictPort: true, // если порт занят — сразу выйдет с ошибкой
   },
   test: {
     globals: true,
-    environment: 'jsdom',
-    setupFiles: './tests/setup.js'
-  }
-})
+    environment: "jsdom",
+    setupFiles: "./tests/setup.js",
+  },
+});


### PR DESCRIPTION
## Summary
- перейти на абсолютные импорты в тестах через алиас `@`
- настроить алиас `@` в vite.config.js
- устранить предупреждения ESLint, добавить недостающие dev-зависимости

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a127b7148324b43e5b64f379c517