### PR TITLE
Создание профиля при регистрации

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -35,15 +35,23 @@ export default function AuthPage() {
   async function onSubmit({ email, password, username }) {
     setError(null)
     if (isRegister) {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: { data: { username } },
-      })
-      if (error) {
-        setError(error.message)
+      const { data: signUpData, error: signUpError } =
+        await supabase.auth.signUp({
+          email,
+          password,
+          options: { data: { username } },
+        })
+      if (signUpError) {
+        setError(signUpError.message)
       } else {
-        navigate('/')
+        const { error: insertError } = await supabase
+          .from('profiles')
+          .insert({ id: signUpData.user.id, username })
+        if (insertError) {
+          setError(insertError.message)
+        } else {
+          navigate('/')
+        }
       }
     } else {
       const { error } = await supabase.auth.signInWithPassword({

--- a/tests/AuthPage.test.jsx
+++ b/tests/AuthPage.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+const insertMock = vi.fn().mockResolvedValue({ error: null })
+const signUpMock = vi
+  .fn()
+  .mockResolvedValue({ data: { user: { id: 'user-id' } }, error: null })
+const getSessionMock = vi.fn(() => Promise.resolve({ data: { session: null } }))
+const onAuthStateChangeMock = vi.fn(() => ({
+  data: { subscription: { unsubscribe: vi.fn() } },
+}))
+
+vi.mock('@/supabaseClient.js', () => ({
+  supabase: {
+    auth: {
+      signUp: signUpMock,
+      signInWithPassword: vi.fn(),
+      getSession: getSessionMock,
+      onAuthStateChange: onAuthStateChangeMock,
+    },
+    from: vi.fn(() => ({ insert: insertMock })),
+  },
+  isSupabaseConfigured: true,
+}))
+
+describe('AuthPage', () => {
+  it('создает профиль при успешной регистрации', async () => {
+    const AuthPage = (await import('@/pages/AuthPage.jsx')).default
+    render(
+      <MemoryRouter>
+        <AuthPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'))
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Пароль'), {
+      target: { value: 'password' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Имя пользователя'), {
+      target: { value: 'testuser' },
+    })
+
+    fireEvent.click(screen.getByText('Зарегистрироваться'))
+
+    await waitFor(() => {
+      expect(signUpMock).toHaveBeenCalled()
+      expect(insertMock).toHaveBeenCalledWith({
+        id: 'user-id',
+        username: 'testuser',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- добавить добавление записи в `profiles` после успешной регистрации
- обработать и выводить ошибки вставки
- покрыть регистрацию тестом

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e73f5bf08324a957d53146d23a9f