### PR TITLE
feat: уведомление о подтверждении регистрации

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,11 +1,26 @@
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient'
+import { pushNotification } from '../utils/notifications'
 
 export function useAuth() {
-  const getSession = () => supabase.auth.getSession();
-  const onAuthStateChange = callback => supabase.auth.onAuthStateChange(callback);
-  const signUp = (email, password, username) =>
-    supabase.auth.signUp({ email, password, options: { data: { username } } });
-  const signIn = (email, password) => supabase.auth.signInWithPassword({ email, password });
-  const signOut = () => supabase.auth.signOut();
-  return { getSession, onAuthStateChange, signUp, signIn, signOut };
+  const getSession = () => supabase.auth.getSession()
+  const onAuthStateChange = (callback) =>
+    supabase.auth.onAuthStateChange(callback)
+  const signUp = async (email, password, username) => {
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { username } },
+    })
+    if (!error && data.user && !data.user.confirmed_at) {
+      pushNotification(
+        'Регистрация',
+        'Проверьте почту для подтверждения аккаунта',
+      )
+    }
+    return { data, error }
+  }
+  const signIn = (email, password) =>
+    supabase.auth.signInWithPassword({ email, password })
+  const signOut = () => supabase.auth.signOut()
+  return { getSession, onAuthStateChange, signUp, signIn, signOut }
 }

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -2,13 +2,15 @@ import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
 import { useNavigate } from 'react-router-dom'
 
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
   const [error, setError] = useState(null)
+  const [info, setInfo] = useState(null)
   const navigate = useNavigate()
+  const { getSession, onAuthStateChange, signUp, signIn } = useAuth()
 
   const schema = z
     .object({
@@ -35,21 +37,16 @@ export default function AuthPage() {
   async function onSubmit({ email, password, username }) {
     setError(null)
     if (isRegister) {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: { data: { username } },
-      })
+      const { data, error } = await signUp(email, password, username)
       if (error) {
         setError(error.message)
+      } else if (data.user && !data.user.confirmed_at) {
+        setInfo('Проверьте почту для подтверждения аккаунта')
       } else {
         navigate('/')
       }
     } else {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      })
+      const { error } = await signIn(email, password)
       if (error) {
         setError(error.message)
       } else {
@@ -60,14 +57,14 @@ export default function AuthPage() {
 
   useEffect(() => {
     let isMounted = true
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    getSession().then(({ data: { session } }) => {
       if (session && isMounted) {
         navigate('/')
       }
     })
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = onAuthStateChange((_event, session) => {
       if (session) {
         navigate('/')
       }
@@ -88,6 +85,7 @@ export default function AuthPage() {
           {isRegister ? 'Регистрация' : 'Вход'}
         </h2>
         {error && <div className="text-red-500 text-sm">{error}</div>}
+        {info && <div className="text-blue-500 text-sm">{info}</div>}
 
         <div>
           <input

--- a/tests/SignupPending.test.jsx
+++ b/tests/SignupPending.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('@/utils/notifications', () => ({
+  requestNotificationPermission: vi.fn(),
+  pushNotification: vi.fn(),
+  playTaskSound: vi.fn(),
+  playMessageSound: vi.fn(),
+}))
+
+const { signUpMock, getSessionMock, onAuthStateChangeMock } = vi.hoisted(() => {
+  return {
+    signUpMock: vi.fn(() =>
+      Promise.resolve({ data: { user: { confirmed_at: null } }, error: null }),
+    ),
+    getSessionMock: vi.fn(() => Promise.resolve({ data: { session: null } })),
+    onAuthStateChangeMock: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+  }
+})
+
+vi.mock('@/supabaseClient.js', () => ({
+  isSupabaseConfigured: true,
+  supabase: {
+    auth: {
+      signUp: signUpMock,
+      signInWithPassword: vi.fn(),
+      getSession: getSessionMock,
+      onAuthStateChange: onAuthStateChangeMock,
+      signOut: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  Toaster: () => null,
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { pushNotification } from '@/utils/notifications'
+import AuthPage from '@/pages/AuthPage.jsx'
+
+describe('AuthPage signUp confirmation', () => {
+  it('показывает сообщение и уведомление при незавершённой регистрации', async () => {
+    render(
+      <MemoryRouter>
+        <AuthPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('Нет аккаунта? Регистрация'))
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Имя пользователя'), {
+      target: { value: 'user' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Пароль'), {
+      target: { value: 'password' },
+    })
+    fireEvent.click(screen.getByText('Зарегистрироваться'))
+
+    expect(
+      await screen.findByText('Проверьте почту для подтверждения аккаунта'),
+    ).toBeInTheDocument()
+    expect(pushNotification).toHaveBeenCalledWith(
+      'Регистрация',
+      'Проверьте почту для подтверждения аккаунта',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- добавить уведомление при незавершённой регистрации
- показывать сообщение о подтверждении на форме входа
- покрыть сценарий незавершённой регистрации тестом

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e7419a28832484956a6706692d35