### PR TITLE
fix: handle signup confirmation and errors

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,26 +1,42 @@
 import { supabase } from '../supabaseClient'
 import { pushNotification } from '../utils/notifications'
+import { useState } from 'react'
 
 export function useAuth() {
+  const [error, setError] = useState(null)
+
   const getSession = () => supabase.auth.getSession()
   const onAuthStateChange = (callback) =>
     supabase.auth.onAuthStateChange(callback)
+
   const signUp = async (email, password, username) => {
-    const { data, error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: { data: { username } },
-    })
-    if (!error && data.user && !data.user.confirmed_at) {
+    setError(null)
+
+    const { data: signUpData, error: signUpError } = await supabase.auth.signUp(
+      {
+        email,
+        password,
+        options: { data: { username } },
+      },
+    )
+
+    if (signUpError) {
+      setError(signUpError.message)
+    } else if (signUpData.user && signUpData.user.confirmed_at === null) {
       pushNotification(
         'Регистрация',
         'Проверьте почту для подтверждения аккаунта',
       )
+      setError('Проверьте почту для подтверждения аккаунта')
     }
-    return { data, error }
+
+    return { data: signUpData, error: signUpError }
   }
+
   const signIn = (email, password) =>
     supabase.auth.signInWithPassword({ email, password })
+
   const signOut = () => supabase.auth.signOut()
-  return { getSession, onAuthStateChange, signUp, signIn, signOut }
+
+  return { getSession, onAuthStateChange, signUp, signIn, signOut, error }
 }

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '../supabaseClient'
 import { useAuth } from '../hooks/useAuth'
 import { useNavigate } from 'react-router-dom'
 
@@ -36,27 +37,17 @@ export default function AuthPage() {
 
   async function onSubmit({ email, password, username }) {
     setError(null)
+    setInfo(null)
     if (isRegister) {
-codex/add-confirmation-notification-for-signup
       const { data, error } = await signUp(email, password, username)
       if (error) {
         setError(error.message)
-      } else if (data.user && !data.user.confirmed_at) {
+      } else if (data.user && data.user.confirmed_at === null) {
         setInfo('Проверьте почту для подтверждения аккаунта')
-
-      const { data: signUpData, error: signUpError } =
-        await supabase.auth.signUp({
-          email,
-          password,
-          options: { data: { username } },
-        })
-      if (signUpError) {
-        setError(signUpError.message)
-main
       } else {
         const { error: insertError } = await supabase
           .from('profiles')
-          .insert({ id: signUpData.user.id, username })
+          .insert({ id: data.user.id, username })
         if (insertError) {
           setError(insertError.message)
         } else {

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -12,14 +12,8 @@ import {
   playTaskSound,
   playMessageSound,
 } from '../utils/notifications'
-codex/handle-errors-and-display-in-toast
-import { Navigate } from 'react-router-dom'
-import Spinner from '../components/Spinner'
-import ErrorMessage from '../components/ErrorMessage'
-
 import { Navigate, useNavigate } from 'react-router-dom'
 import Spinner from '../components/Spinner'
-main
 
 const SELECTED_OBJECT_KEY = 'selectedObjectId'
 const NOTIF_KEY = 'objectNotifications'
@@ -44,12 +38,8 @@ export default function DashboardPage() {
   const [editingObject, setEditingObject] = useState(null)
   const [deleteCandidate, setDeleteCandidate] = useState(null)
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false)
-codex/handle-errors-and-display-in-toast
-  const [objectsError, setObjectsError] = useState(null)
-
   const [fetchError, setFetchError] = useState(null)
   const navigate = useNavigate()
- main
 
   const selectedRef = useRef(null)
   const tabRef = useRef('desc')
@@ -157,21 +147,15 @@ codex/handle-errors-and-display-in-toast
       .select('*')
       .order('created_at', { ascending: true })
     if (error) {
-codex/handle-errors-and-display-in-toast
-      setObjectsError(error)
-      toast.error('Ошибка загрузки объектов: ' + error.message)
-    } else {
-      setObjectsError(null)
-
       if (error.status === 401 || error.status === 403) {
         await supabase.auth.signOut()
         navigate('/auth')
         return
       }
       console.error('Ошибка загрузки объектов:', error)
+      toast.error('Ошибка загрузки объектов: ' + error.message)
       setFetchError('Ошибка загрузки объектов: ' + error.message)
     } else {
- main
       setObjects(data)
       const savedId =
         typeof localStorage !== 'undefined'
@@ -317,17 +301,10 @@ codex/handle-errors-and-display-in-toast
 
   if (!isLoadingUser && !user) return <Navigate to="/auth" replace />
 
- codex/handle-errors-and-display-in-toast
-  if (objectsError) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <ErrorMessage error={objectsError} message="Ошибка загрузки объектов" />
-
   if (fetchError) {
     return (
       <div className="flex items-center justify-center h-screen text-red-500">
         {fetchError}
- main
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- handle signup confirmation with notifications and error state
- clean up AuthPage and DashboardPage merge artifacts
- show toast on object load failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894eefc4224832483043e5fdfc5b854