### PR TITLE
Remove profile creation on user signup

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { supabase } from '../supabaseClient'
 import { useAuth } from '../hooks/useAuth'
 import { useNavigate } from 'react-router-dom'
 
@@ -45,14 +44,7 @@ export default function AuthPage() {
       } else if (data.user && data.user.confirmed_at === null) {
         setInfo('Проверьте почту для подтверждения аккаунта')
       } else {
-        const { error: insertError } = await supabase
-          .from('profiles')
-          .insert({ id: data.user.id, username })
-        if (insertError) {
-          setError(insertError.message)
-        } else {
-          navigate('/')
-        }
+        navigate('/')
       }
     } else {
       const { error } = await signIn(email, password)

--- a/tests/AuthPage.test.jsx
+++ b/tests/AuthPage.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 
-const insertMock = vi.fn().mockResolvedValue({ error: null })
+const fromMock = vi.fn()
 const signUpMock = vi
   .fn()
   .mockResolvedValue({ data: { user: { id: 'user-id' } }, error: null })
@@ -20,13 +20,13 @@ vi.mock('@/supabaseClient.js', () => ({
       getSession: getSessionMock,
       onAuthStateChange: onAuthStateChangeMock,
     },
-    from: vi.fn(() => ({ insert: insertMock })),
+    from: fromMock,
   },
   isSupabaseConfigured: true,
 }))
 
 describe('AuthPage', () => {
-  it('создает профиль при успешной регистрации', async () => {
+  it('регистрирует пользователя без создания профиля', async () => {
     const AuthPage = (await import('@/pages/AuthPage.jsx')).default
     render(
       <MemoryRouter>
@@ -50,10 +50,7 @@ describe('AuthPage', () => {
 
     await waitFor(() => {
       expect(signUpMock).toHaveBeenCalled()
-      expect(insertMock).toHaveBeenCalledWith({
-        id: 'user-id',
-        username: 'testuser',
-      })
+      expect(fromMock).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary
- avoid inserting records into removed `profiles` table on signup
- adjust AuthPage test to ensure no profile insert is triggered

## Testing
- `npm test`
- `npm run lint` (fails: Delete ';' prettier/prettier, Replace vite; with 'vite', etc.)

------
https://chatgpt.com/codex/tasks/task_e_6894f7a075c083249f4ab24eb90c3fb1