### PR TITLE
feat: render chat messages with ChatCard

### DIFF
--- a/src/components/ChatCard.jsx
+++ b/src/components/ChatCard.jsx
@@ -1,15 +1,35 @@
-export default function ChatCard({ item }) {
+import React from 'react'
+import Card from './Card'
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  try {
+    return new Date(dateStr).toLocaleString('ru-RU')
+  } catch {
+    return dateStr
+  }
+}
+
+export default function ChatCard({ message }) {
   return (
-    <div className="p-3 bg-white rounded shadow">
-      <div className="font-medium">{item.platform}</div>
-      <a
-        href={item.link}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-blue-500 underline break-all"
-      >
-        {item.link}
-      </a>
-    </div>
+    <Card className="animate-fade-in">
+      <div className="text-sm text-gray-500 mb-1">
+        {message.sender}
+        {message.created_at && ` • ${formatDate(message.created_at)}`}
+      </div>
+      {message.content && (
+        <p className="whitespace-pre-wrap break-words">{message.content}</p>
+      )}
+      {message.file_url && (
+        <a
+          href={message.file_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 underline break-all"
+        >
+          Вложение
+        </a>
+      )}
+    </Card>
   )
 }

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,5 +1,74 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react'
+import ChatCard from './ChatCard'
+import { useChatMessages } from '../hooks/useChatMessages'
+import { toast } from 'react-hot-toast'
 
-export default function ChatTab() {
-  return <div>Chat</div>;
+export default function ChatTab({ selected, user }) {
+  const [messages, setMessages] = useState([])
+  const [content, setContent] = useState('')
+  const [file, setFile] = useState(null)
+  const messagesEndRef = useRef(null)
+  const { fetchMessages, sendMessage, subscribeToMessages } = useChatMessages()
+
+  useEffect(() => {
+    if (!selected) return
+    fetchMessages(selected.id).then(({ data, error }) => {
+      if (error) toast.error('Ошибка загрузки сообщений: ' + error.message)
+      else setMessages(data || [])
+    })
+    const unsubscribe = subscribeToMessages(selected.id, (payload) => {
+      setMessages((prev) => [...prev, payload.new])
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [selected])
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!content && !file) return
+    const { data, error } = await sendMessage({
+      objectId: selected.id,
+      sender: user?.email,
+      content,
+      file,
+    })
+    if (error) toast.error('Ошибка отправки: ' + error.message)
+    else {
+      setMessages((prev) => [...prev, data])
+      setContent('')
+      setFile(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto space-y-2 mb-4">
+        {messages.map((m) => (
+          <ChatCard key={m.id} message={m} />
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <textarea
+          className="textarea textarea-bordered w-full"
+          placeholder="Сообщение"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="file-input file-input-bordered w-full"
+        />
+        <button type="submit" className="btn btn-primary self-end">
+          Отправить
+        </button>
+      </form>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- расширен ChatCard для отображения отправителя, времени, текста и вложений
- реализован ChatTab: загрузка, подписка и отправка сообщений, вывод через ChatCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68950a7d05b88324b415643db3e31dd4