### PR TITLE
Добавлен тест ChatTab с моками useChatMessages

### DIFF
--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+const initialMessages = [
+  { id: '1', sender: 'Alice', content: 'Привет' },
+  { id: '2', sender: 'Bob', content: 'Здравствуйте' },
+]
+
+const fetchMessagesMock = vi.fn(() =>
+  Promise.resolve({ data: initialMessages, error: null }),
+)
+let subscribeHandler
+const subscribeToMessagesMock = vi.fn((_objectId, handler) => {
+  subscribeHandler = handler
+  return () => {}
+})
+const sendMessageMock = vi.fn(async ({ objectId, sender, content }) => {
+  const newMessage = {
+    id: String(Date.now()),
+    object_id: objectId,
+    sender,
+    content,
+  }
+  if (subscribeHandler) {
+    subscribeHandler({ new: newMessage })
+  }
+  return { data: newMessage, error: null }
+})
+
+vi.mock('@/hooks/useChatMessages.js', () => ({
+  useChatMessages: () => ({
+    fetchMessages: fetchMessagesMock,
+    sendMessage: sendMessageMock,
+    subscribeToMessages: subscribeToMessagesMock,
+  }),
+}))
+
+import ChatTab from '@/components/ChatTab.jsx'
+
+describe('ChatTab', () => {
+  it('отображает сообщения и форму отправки', async () => {
+    render(<ChatTab objectId="1" sender="me" />)
+    for (const msg of initialMessages) {
+      expect(await screen.findByText(msg.content)).toBeInTheDocument()
+    }
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('отправляет новое сообщение', async () => {
+    render(<ChatTab objectId="1" sender="me" />)
+    const input = await screen.findByRole('textbox')
+    const button = screen.getByRole('button')
+    fireEvent.change(input, { target: { value: 'Новое сообщение' } })
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalled()
+      expect(screen.getByText('Новое сообщение')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- добавлен тест для ChatTab с моком useChatMessages
- проверяется отображение сообщений, формы и отправка нового сообщения

## Testing
- `npm test` (провалился: Unable to find an element with the text: Привет, Unable to find role="textbox")

------
https://chatgpt.com/codex/tasks/task_e_68950a8dc0008324a1600c90828b8199