### PR TITLE
Convert Tailwind config to ESM and integrate DaisyUI plugin

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,7 +1,7 @@
-/* eslint-env node */
-/* eslint-disable no-undef */
+import daisyui from 'daisyui';
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
@@ -17,8 +17,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require('daisyui')],
+  plugins: [daisyui],
   daisyui: {
     themes: ['light', 'dark', 'cupcake', 'retro', 'cyberpunk'],
   },
-}
+};


### PR DESCRIPTION
## Summary
- rename Tailwind config to `tailwind.config.mjs`
- switch config to ESM with DaisyUI plugin

## Testing
- `npm run build`
- `npm test` *(fails: Test Files 1 failed | 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68970fe67ab883248aa6fb66bdd600b2