### PR TITLE
feat: add role column and task policies

### DIFF
--- a/supabase/migrations/20250809092400_add-role-and-task-policies.sql
+++ b/supabase/migrations/20250809092400_add-role-and-task-policies.sql
@@ -1,0 +1,5 @@
+ALTER TABLE profiles ADD COLUMN role text DEFAULT 'user';
+CREATE POLICY "Admins can insert tasks" ON tasks FOR INSERT USING (
+  EXISTS (SELECT 1 FROM profiles p WHERE p.id = auth.uid() AND p.role = 'admin')
+);
+CREATE POLICY "Users can update own tasks" ON tasks FOR UPDATE USING (assignee = auth.uid());


### PR DESCRIPTION
## Summary
- add role column to profiles and task policies for admins and assignees

## Testing
- `npx supabase db push` *(fails: Cannot find project ref)*
- `npm test` *(fails: 1 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6897136e28d88324a55a07ab1f760611