### PR TITLE
feat: add admin route component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { Toaster } from 'react-hot-toast';
-import AuthPage from './pages/AuthPage';
-import DashboardPage from './pages/DashboardPage';
-import MissingEnvPage from './pages/MissingEnvPage';
-import { isSupabaseConfigured } from './supabaseClient';
+import React from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { Toaster } from 'react-hot-toast'
+import AuthPage from './pages/AuthPage'
+import DashboardPage from './pages/DashboardPage'
+import MissingEnvPage from './pages/MissingEnvPage'
+import { isSupabaseConfigured } from './supabaseClient'
+import AdminRoute from './components/AdminRoute'
 
 export default function App() {
   if (!isSupabaseConfigured) {
-    return <MissingEnvPage />;
+    return <MissingEnvPage />
   }
 
   return (
@@ -16,8 +17,15 @@ export default function App() {
       <Toaster position="top-right" />
       <Routes>
         <Route path="/auth" element={<AuthPage />} />
-        <Route path="/*" element={<DashboardPage />} />
+        <Route
+          path="/*"
+          element={
+            <AdminRoute>
+              <DashboardPage />
+            </AdminRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
-  );
+  )
 }

--- a/src/components/AdminRoute.jsx
+++ b/src/components/AdminRoute.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function AdminRoute({ children }) {
+  const { isAdmin } = useAuth()
+  return isAdmin ? children : <Navigate to="/" replace />
+}


### PR DESCRIPTION
## Summary
- add AdminRoute component to guard admin-only pages
- wrap dashboard routes with AdminRoute

## Testing
- `npm test` (fails: tests/ChatTab.test.jsx)

------
https://chatgpt.com/codex/tasks/task_e_689714a6a3048324b7c0e0e2565e1da3