### PR TITLE
feat: add auth context and hook

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,62 @@
+import { createContext, useEffect, useState } from 'react'
+import { supabase, isSupabaseConfigured } from '../supabaseClient'
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const AuthContext = createContext({ user: null, role: null })
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [role, setRole] = useState(null)
+
+  useEffect(() => {
+    if (!isSupabaseConfigured) return
+
+    const fetchSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      const currentUser = session?.user ?? null
+      setUser(currentUser)
+
+      if (currentUser) {
+        const { data } = await supabase
+          .from('profiles')
+          .select('role')
+          .eq('id', currentUser.id)
+          .single()
+        setRole(data?.role ?? null)
+      } else {
+        setRole(null)
+      }
+    }
+
+    fetchSession()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      const currentUser = session?.user ?? null
+      setUser(currentUser)
+      if (currentUser) {
+        supabase
+          .from('profiles')
+          .select('role')
+          .eq('id', currentUser.id)
+          .single()
+          .then(({ data }) => setRole(data?.role ?? null))
+      } else {
+        setRole(null)
+      }
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, role }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,42 +1,7 @@
-import { supabase } from '../supabaseClient'
-import { pushNotification } from '../utils/notifications'
-import { useState } from 'react'
+import { useContext } from 'react'
+import { AuthContext } from '../context/AuthContext'
 
 export function useAuth() {
-  const [error, setError] = useState(null)
-
-  const getSession = () => supabase.auth.getSession()
-  const onAuthStateChange = (callback) =>
-    supabase.auth.onAuthStateChange(callback)
-
-  const signUp = async (email, password, username) => {
-    setError(null)
-
-    const { data: signUpData, error: signUpError } = await supabase.auth.signUp(
-      {
-        email,
-        password,
-        options: { data: { username } },
-      },
-    )
-
-    if (signUpError) {
-      setError(signUpError.message)
-    } else if (signUpData.user && signUpData.user.confirmed_at === null) {
-      pushNotification(
-        'Регистрация',
-        'Проверьте почту для подтверждения аккаунта',
-      )
-      setError('Проверьте почту для подтверждения аккаунта')
-    }
-
-    return { data: signUpData, error: signUpError }
-  }
-
-  const signIn = (email, password) =>
-    supabase.auth.signInWithPassword({ email, password })
-
-  const signOut = () => supabase.auth.signOut()
-
-  return { getSession, onAuthStateChange, signUp, signIn, signOut, error }
+  const { user, role } = useContext(AuthContext)
+  return { user, isAdmin: role === 'admin', isUser: role === 'user' }
 }

--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { supabase } from '../supabaseClient'
+import { pushNotification } from '../utils/notifications'
+
+export function useSupabaseAuth() {
+  const [error, setError] = useState(null)
+
+  const getSession = () => supabase.auth.getSession()
+  const onAuthStateChange = (callback) =>
+    supabase.auth.onAuthStateChange(callback)
+
+  const signUp = async (email, password, username) => {
+    setError(null)
+
+    const { data: signUpData, error: signUpError } = await supabase.auth.signUp(
+      {
+        email,
+        password,
+        options: { data: { username } },
+      },
+    )
+
+    if (signUpError) {
+      setError(signUpError.message)
+    } else if (signUpData.user && signUpData.user.confirmed_at === null) {
+      pushNotification(
+        'Регистрация',
+        'Проверьте почту для подтверждения аккаунта',
+      )
+      setError('Проверьте почту для подтверждения аккаунта')
+    }
+
+    return { data: signUpData, error: signUpError }
+  }
+
+  const signIn = (email, password) =>
+    supabase.auth.signInWithPassword({ email, password })
+
+  const signOut = () => supabase.auth.signOut()
+
+  return { getSession, onAuthStateChange, signUp, signIn, signOut, error }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import './index.css';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './index.css'
+import { AuthProvider } from './context/AuthContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
-  </StrictMode>
-);
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </StrictMode>,
+)

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useAuth } from '../hooks/useAuth'
+import { useSupabaseAuth } from '../hooks/useSupabaseAuth'
 import { useNavigate } from 'react-router-dom'
 
 export default function AuthPage() {
@@ -10,7 +10,7 @@ export default function AuthPage() {
   const [error, setError] = useState(null)
   const [info, setInfo] = useState(null)
   const navigate = useNavigate()
-  const { getSession, onAuthStateChange, signUp, signIn } = useAuth()
+  const { getSession, onAuthStateChange, signUp, signIn } = useSupabaseAuth()
 
   const schema = z
     .object({


### PR DESCRIPTION
## Summary
- provide authentication context that loads user session and role
- expose useAuth hook with user role helpers
- wrap application with AuthProvider and rename original auth hook

## Testing
- `npm test` *(fails: Transform failed in tests/ChatTab.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689714a469d88324bddbb68c4a447d9b