### PR TITLE
refactor: rename useAuth hook to useAuthActions

### DIFF
--- a/src/hooks/useAuthActions.js
+++ b/src/hooks/useAuthActions.js
@@ -2,7 +2,7 @@ import { supabase } from '../supabaseClient'
 import { pushNotification } from '../utils/notifications'
 import { useState } from 'react'
 
-export function useAuth() {
+export function useAuthActions() {
   const [error, setError] = useState(null)
 
   const getSession = () => supabase.auth.getSession()

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useAuth } from '../hooks/useAuth'
+import { useAuthActions } from '../hooks/useAuthActions'
 import { useNavigate } from 'react-router-dom'
 
 export default function AuthPage() {
@@ -10,7 +10,7 @@ export default function AuthPage() {
   const [error, setError] = useState(null)
   const [info, setInfo] = useState(null)
   const navigate = useNavigate()
-  const { getSession, onAuthStateChange, signUp, signIn } = useAuth()
+  const { getSession, onAuthStateChange, signUp, signIn } = useAuthActions()
 
   const schema = z
     .object({


### PR DESCRIPTION
## Summary
- rename useAuth hook file to useAuthActions and keep auth helper functions
- update AuthPage to use useAuthActions

## Testing
- `npm test` *(fails: tests/ChatTab.test.jsx - symbol already declared)*
- `npm run lint` *(fails: multiple prettier errors in tests and config)*

------
https://chatgpt.com/codex/tasks/task_e_689714a589848324a832f66edc45c72a