### PR TITLE
Restrict admin actions and handle RLS errors

### DIFF
--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -1,9 +1,14 @@
 // src/components/HardwareCard.jsx
-import React from 'react';
-import Card from './Card';
-import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import React from 'react'
+import Card from './Card'
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
-export default function HardwareCard({ item, onEdit, onDelete }) {
+export default function HardwareCard({
+  item,
+  onEdit,
+  onDelete,
+  isAdmin = false,
+}) {
   return (
     <Card className="flex justify-between items-center">
       <div>
@@ -14,16 +19,24 @@ export default function HardwareCard({ item, onEdit, onDelete }) {
           <span>Установка: {item.install_status}</span>
         </div>
       </div>
-      <div className="flex space-x-2">
-        <button onClick={onEdit} className="btn btn-sm btn-outline flex items-center gap-1">
-          <PencilIcon className="w-4 h-4" />
-          Изменить
-        </button>
-        <button onClick={onDelete} className="btn btn-sm btn-error flex items-center gap-1">
-          <TrashIcon className="w-4 h-4" />
-          Удалить
-        </button>
-      </div>
+      {isAdmin && (
+        <div className="flex space-x-2">
+          <button
+            onClick={onEdit}
+            className="btn btn-sm btn-outline flex items-center gap-1"
+          >
+            <PencilIcon className="w-4 h-4" />
+            Изменить
+          </button>
+          <button
+            onClick={onDelete}
+            className="btn btn-sm btn-error flex items-center gap-1"
+          >
+            <TrashIcon className="w-4 h-4" />
+            Удалить
+          </button>
+        </div>
+      )}
     </Card>
-  );
+  )
 }

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import Card from './Card';
-import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import React from 'react'
+import Card from './Card'
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
 export default function InventorySidebar({
   objects,
@@ -8,17 +8,20 @@ export default function InventorySidebar({
   onSelect,
   onEdit,
   onDelete,
-  notifications = {}
+  notifications = {},
+  isAdmin = false,
 }) {
   return (
     <nav className="flex flex-col space-y-2">
-      {objects.map(o => (
+      {objects.map((o) => (
         <Card key={o.id} className="flex items-center justify-between p-2">
           <div className="flex items-center flex-1">
             <button
               onClick={() => onSelect(o)}
               className={`flex-1 text-left px-3 py-2 rounded hover:bg-primary/10 ${
-                selected?.id === o.id ? 'border-b-2 border-primary font-medium' : ''
+                selected?.id === o.id
+                  ? 'border-b-2 border-primary font-medium'
+                  : ''
               }`}
             >
               {o.name}
@@ -29,22 +32,26 @@ export default function InventorySidebar({
               </span>
             ) : null}
           </div>
-          <button
-            onClick={() => onEdit(o)}
-            className="ml-2 text-primary hover:text-primary/70"
-            title="Редактировать объект"
-          >
-            <PencilIcon className="w-4 h-4" />
-          </button>
-          <button
-            onClick={() => onDelete(o.id)}
-            className="ml-2 text-red-500 hover:text-red-700"
-            title="Удалить объект"
-          >
-            <TrashIcon className="w-4 h-4" />
-          </button>
+          {isAdmin && (
+            <>
+              <button
+                onClick={() => onEdit(o)}
+                className="ml-2 text-primary hover:text-primary/70"
+                title="Редактировать объект"
+              >
+                <PencilIcon className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => onDelete(o.id)}
+                className="ml-2 text-red-500 hover:text-red-700"
+                title="Удалить объект"
+              >
+                <TrashIcon className="w-4 h-4" />
+              </button>
+            </>
+          )}
         </Card>
       ))}
     </nav>
-);
+  )
 }

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -39,6 +39,7 @@ export default function InventoryTabs({
   selected,
   onUpdateSelected,
   user,
+  isAdmin = false,
   onTabChange = () => {},
 }) {
   // --- вкладки и описание ---
@@ -219,8 +220,10 @@ export default function InventoryTabs({
     fetchHardware(selected.id, 0)
     fetchTasks(selected.id, 0)
     fetchMessages(selected.id).then(({ data, error }) => {
-      if (error) toast.error('Ошибка загрузки сообщений: ' + error.message)
-      else setChatMessages(data || [])
+      if (error) {
+        if (error.status === 403) toast.error('Недостаточно прав')
+        else toast.error('Ошибка загрузки сообщений: ' + error.message)
+      } else setChatMessages(data || [])
     })
   }, [selected])
 
@@ -312,7 +315,10 @@ export default function InventoryTabs({
     if (!error) {
       onUpdateSelected({ ...selected, description: data.description })
       setIsEditingDesc(false)
-    } else toast.error('Ошибка сохранения описания: ' + error.message)
+    } else {
+      if (error.status === 403) toast.error('Недостаточно прав')
+      else toast.error('Ошибка сохранения описания: ' + error.message)
+    }
   }
 
   // --- CRUD Оборудование ---
@@ -331,7 +337,8 @@ export default function InventoryTabs({
       .range(from, to)
     if (error) {
       setHardwareError(error)
-      toast.error('Ошибка загрузки оборудования: ' + error.message)
+      if (error.status === 403) toast.error('Недостаточно прав')
+      else toast.error('Ошибка загрузки оборудования: ' + error.message)
     } else {
       setHardware((prev) => [...prev, ...(data || [])])
       if (!data || data.length < PAGE_SIZE) {
@@ -341,9 +348,10 @@ export default function InventoryTabs({
       }
     }
     const { data: apiData, error: apiError } = await fetchHardwareApi(objectId)
-    if (apiError)
-      toast.error('Ошибка загрузки оборудования: ' + apiError.message)
-    else setHardware(apiData || [])
+    if (apiError) {
+      if (apiError.status === 403) toast.error('Недостаточно прав')
+      else toast.error('Ошибка загрузки оборудования: ' + apiError.message)
+    } else setHardware(apiData || [])
 
     setLoadingHW(false)
   }
@@ -372,7 +380,9 @@ export default function InventoryTabs({
       res = await insertHardware(payload)
     }
     if (res.error)
-      return toast.error('Ошибка оборудования: ' + res.error.message)
+      return res.error.status === 403
+        ? toast.error('Недостаточно прав')
+        : toast.error('Ошибка оборудования: ' + res.error.message)
     const rec = res.data
     setHardware((prev) =>
       editingHW ? prev.map((h) => (h.id === rec.id ? rec : h)) : [...prev, rec],
@@ -387,7 +397,10 @@ export default function InventoryTabs({
   async function confirmDeleteHardware() {
     const id = hwDeleteId
     const { error } = await deleteHardware(id)
-    if (error) return toast.error('Ошибка удаления: ' + error.message)
+    if (error)
+      return error.status === 403
+        ? toast.error('Недостаточно прав')
+        : toast.error('Ошибка удаления: ' + error.message)
     setHardware((prev) => prev.filter((h) => h.id !== id))
     setHwDeleteId(null)
   }
@@ -408,7 +421,8 @@ export default function InventoryTabs({
       .range(from, to)
     if (error) {
       setTasksError(error)
-      toast.error('Ошибка загрузки задач: ' + error.message)
+      if (error.status === 403) toast.error('Недостаточно прав')
+      else toast.error('Ошибка загрузки задач: ' + error.message)
     } else {
       setTasks((prev) => [...prev, ...(data || [])])
       if (!data || data.length < PAGE_SIZE) {
@@ -418,8 +432,10 @@ export default function InventoryTabs({
       }
     }
     const { data: apiData, error: apiError } = await fetchTasksApi(objectId)
-    if (apiError) toast.error('Ошибка загрузки задач: ' + apiError.message)
-    else setTasks(apiData || [])
+    if (apiError) {
+      if (apiError.status === 403) toast.error('Недостаточно прав')
+      else toast.error('Ошибка загрузки задач: ' + apiError.message)
+    } else setTasks(apiData || [])
     setLoadingTasks(false)
   }
 
@@ -460,7 +476,10 @@ export default function InventoryTabs({
     } else {
       res = await insertTask(payload)
     }
-    if (res.error) return toast.error('Ошибка задач: ' + res.error.message)
+    if (res.error)
+      return res.error.status === 403
+        ? toast.error('Недостаточно прав')
+        : toast.error('Ошибка задач: ' + res.error.message)
     const rec = res.data
     setTasks((prev) =>
       editingTask
@@ -478,7 +497,10 @@ export default function InventoryTabs({
   async function confirmDeleteTask() {
     const id = taskDeleteId
     const { error } = await deleteTask(id)
-    if (error) return toast.error('Ошибка удаления: ' + error.message)
+    if (error)
+      return error.status === 403
+        ? toast.error('Недостаточно прав')
+        : toast.error('Ошибка удаления: ' + error.message)
     setTasks((prev) => prev.filter((t) => t.id !== id))
     setTaskDeleteId(null)
   }
@@ -567,12 +589,14 @@ export default function InventoryTabs({
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Оборудование</h3>
-              <button
-                className="btn btn-sm btn-primary flex items-center gap-1"
-                onClick={() => openHWModal()}
-              >
-                <PlusIcon className="w-4 h-4" /> Добавить
-              </button>
+              {isAdmin && (
+                <button
+                  className="btn btn-sm btn-primary flex items-center gap-1"
+                  onClick={() => openHWModal()}
+                >
+                  <PlusIcon className="w-4 h-4" /> Добавить
+                </button>
+              )}
             </div>
             {loadingHW && <Spinner />}
             {hardwareError && (
@@ -589,6 +613,7 @@ export default function InventoryTabs({
                     item={h}
                     onEdit={() => openHWModal(h)}
                     onDelete={() => askDeleteHardware(h.id)}
+                    isAdmin={isAdmin}
                   />
                 ))}
               </div>
@@ -718,12 +743,14 @@ export default function InventoryTabs({
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Задачи</h3>
-              <button
-                className="btn btn-sm btn-primary flex items-center gap-1"
-                onClick={() => openTaskModal()}
-              >
-                <PlusIcon className="w-4 h-4" /> Добавить задачу
-              </button>
+              {isAdmin && (
+                <button
+                  className="btn btn-sm btn-primary flex items-center gap-1"
+                  onClick={() => openTaskModal()}
+                >
+                  <PlusIcon className="w-4 h-4" /> Добавить задачу
+                </button>
+              )}
             </div>
             {loadingTasks && <Spinner />}
             {tasksError && (
@@ -741,6 +768,8 @@ export default function InventoryTabs({
                     onView={() => openTaskView(t)}
                     onEdit={() => openTaskModal(t)}
                     onDelete={() => askDeleteTask(t.id)}
+                    user={user}
+                    isAdmin={isAdmin}
                   />
                 ))}
               </div>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,29 +1,38 @@
-import React from 'react';
-import Card from './Card';
-import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import React from 'react'
+import Card from './Card'
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
 /**
  * Format date string into locale friendly format.
  * Falls back to original value on parse errors.
  */
 function formatDate(dateStr) {
-  if (!dateStr) return '';
+  if (!dateStr) return ''
   try {
-    return new Date(dateStr).toLocaleDateString('ru-RU');
+    return new Date(dateStr).toLocaleDateString('ru-RU')
   } catch {
-    return dateStr;
+    return dateStr
   }
 }
 
-export default function TaskCard({ item, onEdit, onDelete, onView }) {
-  const badgeClass = {
-    'запланировано': 'badge-info',
-    'в процессе':    'badge-warning',
-    'завершено':     'badge-success'
-  }[item.status] || 'badge';
+export default function TaskCard({
+  item,
+  onEdit,
+  onDelete,
+  onView,
+  user = {},
+  isAdmin = false,
+}) {
+  const badgeClass =
+    {
+      запланировано: 'badge-info',
+      'в процессе': 'badge-warning',
+      завершено: 'badge-success',
+    }[item.status] || 'badge'
 
-  const assignee = item.assignee || item.executor;
-  const dueDate  = item.due_date || item.planned_date || item.plan_date;
+  const assignee = item.assignee || item.executor
+  const dueDate = item.due_date || item.planned_date || item.plan_date
+  const canManage = isAdmin || item.assignee === user?.id
 
   return (
     <Card
@@ -42,27 +51,31 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
       </div>
       <div className="flex items-center space-x-2">
         <span className={`badge ${badgeClass}`}>{item.status}</span>
-        <button
-          className="btn btn-sm btn-ghost"
-          title="Редактировать"
-          onClick={e => {
-            e.stopPropagation();
-            onEdit();
-          }}
-        >
-          <PencilIcon className="w-4 h-4" />
-        </button>
-        <button
-          className="btn btn-sm btn-ghost"
-          title="Удалить"
-          onClick={e => {
-            e.stopPropagation();
-            onDelete();
-          }}
-        >
-          <TrashIcon className="w-4 h-4" />
-        </button>
+        {canManage && (
+          <>
+            <button
+              className="btn btn-sm btn-ghost"
+              title="Редактировать"
+              onClick={(e) => {
+                e.stopPropagation()
+                onEdit()
+              }}
+            >
+              <PencilIcon className="w-4 h-4" />
+            </button>
+            <button
+              className="btn btn-sm btn-ghost"
+              title="Удалить"
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete()
+              }}
+            >
+              <TrashIcon className="w-4 h-4" />
+            </button>
+          </>
+        )}
       </div>
     </Card>
-  );
+  )
 }

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -1,97 +1,114 @@
-codex/ensure-single-test-filename-format
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import ChatTab from '../src/components/ChatTab.jsx';
-import { toast } from 'react-hot-toast';
+// codex/ensure-single-test-filename-format
+import React from 'react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ChatTab from '../src/components/ChatTab.jsx'
+import { toast } from 'react-hot-toast'
 
-const { uploadMock, insertMock, supabaseMock, toastErrorMock } = vi.hoisted(() => {
-  const uploadMock = vi.fn();
-  const getPublicUrlMock = vi.fn(() => ({ data: { publicUrl: 'public-url' } }));
-  const singleMock = vi.fn().mockResolvedValue({ data: { id: '1' }, error: null });
-  const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }));
-  const insertMock = vi.fn(() => ({ select: selectAfterInsertMock }));
-  const selectMock = vi.fn(() => ({
-    eq: vi.fn(() => ({
-      order: vi.fn(() => ({
-        then: vi.fn(cb => {
-          cb({ data: [], error: null });
-          return Promise.resolve({ data: [], error: null });
-        })
-      }))
+const { uploadMock, insertMock, supabaseMock, toastErrorMock } = vi.hoisted(
+  () => {
+    const uploadMock = vi.fn()
+    const getPublicUrlMock = vi.fn(() => ({
+      data: { publicUrl: 'public-url' },
     }))
-  }));
-  const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock }));
-  const channelMock = vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() }));
-  const removeChannelMock = vi.fn();
-  const supabaseMock = {
-    from: fromMock,
-    storage: { from: vi.fn(() => ({ upload: uploadMock, getPublicUrl: getPublicUrlMock })) },
-    channel: channelMock,
-    removeChannel: removeChannelMock,
-  };
-  const toastErrorMock = vi.fn();
-  return { uploadMock, insertMock, supabaseMock, toastErrorMock };
-});
+    const singleMock = vi
+      .fn()
+      .mockResolvedValue({ data: { id: '1' }, error: null })
+    const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }))
+    const insertMock = vi.fn(() => ({ select: selectAfterInsertMock }))
+    const selectMock = vi.fn(() => ({
+      eq: vi.fn(() => ({
+        order: vi.fn(() => ({
+          then: vi.fn((cb) => {
+            cb({ data: [], error: null })
+            return Promise.resolve({ data: [], error: null })
+          }),
+        })),
+      })),
+    }))
+    const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock }))
+    const channelMock = vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    }))
+    const removeChannelMock = vi.fn()
+    const supabaseMock = {
+      from: fromMock,
+      storage: {
+        from: vi.fn(() => ({
+          upload: uploadMock,
+          getPublicUrl: getPublicUrlMock,
+        })),
+      },
+      channel: channelMock,
+      removeChannel: removeChannelMock,
+    }
+    const toastErrorMock = vi.fn()
+    return { uploadMock, insertMock, supabaseMock, toastErrorMock }
+  },
+)
 
 vi.mock('../src/supabaseClient.js', () => ({
   supabase: supabaseMock,
-}));
+}))
 
 vi.mock('react-hot-toast', () => ({
   toast: { error: toastErrorMock },
-}));
+}))
 
-const user = { user_metadata: { username: 'Tester' }, email: 'test@example.com' };
-const selected = { id: 'object1' };
+const user = {
+  user_metadata: { username: 'Tester' },
+  email: 'test@example.com',
+}
+const selected = { id: 'object1' }
 
 describe('ChatTab file upload', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.clearAllMocks()
     // jsdom doesn't implement scrollIntoView
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  });
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
 
   it('sends message when upload succeeds', async () => {
-    uploadMock.mockResolvedValue({ data: {}, error: null });
+    uploadMock.mockResolvedValue({ data: {}, error: null })
 
-    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
-    const textarea = getByPlaceholderText('Введите сообщение...');
-    fireEvent.change(textarea, { target: { value: 'Hello' } });
-    const fileInput = container.querySelector('input[type="file"]');
-    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
+    const { container, getByPlaceholderText } = render(
+      <ChatTab selected={selected} user={user} />,
+    )
+    const textarea = getByPlaceholderText('Введите сообщение...')
+    fireEvent.change(textarea, { target: { value: 'Hello' } })
+    const fileInput = container.querySelector('input[type="file"]')
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
 
-    const sendButton = container.querySelector('button');
-    await fireEvent.click(sendButton);
+    const sendButton = container.querySelector('button')
+    await fireEvent.click(sendButton)
 
-    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
-    expect(insertMock).toHaveBeenCalled();
-    expect(toast.error).not.toHaveBeenCalled();
-  });
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled())
+    expect(insertMock).toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
 
   it('shows error and blocks message on upload failure', async () => {
-    uploadMock.mockResolvedValue({ data: null, error: new Error('fail') });
+    uploadMock.mockResolvedValue({ data: null, error: new Error('fail') })
 
-    const { container, getByPlaceholderText } = render(<ChatTab selected={selected} user={user} />);
-    const textarea = getByPlaceholderText('Введите сообщение...');
-    fireEvent.change(textarea, { target: { value: 'Hello' } });
-    const fileInput = container.querySelector('input[type="file"]');
-    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
+    const { container, getByPlaceholderText } = render(
+      <ChatTab selected={selected} user={user} />,
+    )
+    const textarea = getByPlaceholderText('Введите сообщение...')
+    fireEvent.change(textarea, { target: { value: 'Hello' } })
+    const fileInput = container.querySelector('input[type="file"]')
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
 
-    const sendButton = container.querySelector('button');
-    await fireEvent.click(sendButton);
+    const sendButton = container.querySelector('button')
+    await fireEvent.click(sendButton)
 
-    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
-    expect(toastErrorMock).toHaveBeenCalled();
-    expect(insertMock).not.toHaveBeenCalled();
-  });
-});
-
-import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled())
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(insertMock).not.toHaveBeenCalled()
+  })
+})
 
 const initialMessages = [
   { id: '1', sender: 'Alice', content: 'Привет' },
@@ -127,8 +144,6 @@ vi.mock('@/hooks/useChatMessages.js', () => ({
   }),
 }))
 
-import ChatTab from '@/components/ChatTab.jsx'
-
 describe('ChatTab', () => {
   it('отображает сообщения и форму отправки', async () => {
     render(<ChatTab selected={{ id: '1' }} user={{ email: 'me' }} />)
@@ -151,4 +166,3 @@ describe('ChatTab', () => {
     })
   })
 })
-main


### PR DESCRIPTION
## Summary
- show object add button and hardware/task actions only for admins
- allow task edit/delete for assignee or admin
- handle RLS (403) errors with toast notifications

## Testing
- `npm test` *(fails: Unable to find placeholder text in ChatTab tests)*

------
https://chatgpt.com/codex/tasks/task_e_689714a8e3f08324b15b133d759bdad2