### PR TITLE
Add xs and sm2 Tailwind screens

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,6 +15,10 @@ export default {
         body: '1rem',
         caption: '0.875rem',
       },
+      screens: {
+        xs: '320px',
+        sm2: '480px',
+      },
     },
   },
   plugins: [daisyui],


### PR DESCRIPTION
## Summary
- add xs (320px) and sm2 (480px) responsive breakpoints to Tailwind config

## Testing
- `npm run build`
- `npx tailwindcss -c tailwind.config.mjs --content src/tmp-check.jsx -o /tmp/tailwind.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689725bcb4ec832497fc819ec3899443