### PR TITLE
feat: improve dashboard header responsiveness

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -154,7 +154,6 @@ export default function DashboardPage() {
       .select('*')
       .order('created_at', { ascending: true })
     if (error) {
-
       if (error.status === 401) {
         await supabase.auth.signOut()
         navigate('/auth')
@@ -199,13 +198,11 @@ export default function DashboardPage() {
         .select()
         .single()
       if (error) {
-
         if (error.status === 403) toast.error('Недостаточно прав')
         else toast.error('Ошибка редактирования: ' + error.message)
 
         await handleSupabaseError(error, navigate, 'Ошибка редактирования')
         return
-
       } else {
         setObjects((prev) =>
           prev.map((o) => (o.id === editingObject.id ? data : o)),
@@ -222,13 +219,11 @@ export default function DashboardPage() {
         .select()
         .single()
       if (error) {
-
         if (error.status === 403) toast.error('Недостаточно прав')
         else toast.error('Ошибка добавления: ' + error.message)
 
         await handleSupabaseError(error, navigate, 'Ошибка добавления')
         return
-
       } else {
         setObjects((prev) => [...prev, data])
         setSelected(data)
@@ -250,13 +245,11 @@ export default function DashboardPage() {
     const id = deleteCandidate
     const { error } = await supabase.from('objects').delete().eq('id', id)
     if (error) {
-
       if (error.status === 403) toast.error('Недостаточно прав')
       else toast.error('Ошибка удаления: ' + error.message)
 
       await handleSupabaseError(error, navigate, 'Ошибка удаления')
       return
-
     } else {
       setObjects((prev) => {
         const updated = prev.filter((o) => o.id !== id)
@@ -375,7 +368,7 @@ export default function DashboardPage() {
             />
             <aside className="relative z-20 w-72 bg-gray-50 p-4 shadow-lg overflow-y-auto">
               <button
-                className="btn btn-sm btn-circle absolute right-2 top-2"
+                className="btn btn-circle btn-md md:btn-sm absolute right-2 top-2"
                 onClick={toggleSidebar}
               >
                 ✕
@@ -396,14 +389,14 @@ export default function DashboardPage() {
         {/* Основная часть */}
         <div className="flex-1 flex flex-col">
           {/* Хэдер с одной фиолетовой кнопкой */}
-          <header className="flex items-center justify-between p-4 border-b bg-white">
+          <header className="flex flex-col xs:items-start xs:gap-2 md:flex-row items-center justify-between p-4 border-b bg-white">
             <div className="flex items-center gap-2">
-              <button className="md:hidden text-2xl" onClick={toggleSidebar}>
+              <button className="md:hidden p-2 text-lg" onClick={toggleSidebar}>
                 ☰
               </button>
               {isAdmin && (
                 <button
-                  className="btn btn-primary btn-sm flex items-center gap-1"
+                  className="btn btn-primary btn-md md:btn-sm flex items-center gap-1"
                   onClick={() => {
                     setEditingObject(null)
                     setObjectName('')
@@ -416,13 +409,13 @@ export default function DashboardPage() {
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="btn btn-sm"
+                className="btn btn-md md:btn-sm p-2 text-lg md:text-sm"
                 onClick={() => setIsAccountModalOpen(true)}
               >
                 {user.user_metadata?.username || 'Аккаунт'}
               </button>
               <button
-                className="btn btn-sm"
+                className="btn btn-md md:btn-sm p-2 text-lg md:text-sm"
                 onClick={() => supabase.auth.signOut()}
               >
                 Выйти
@@ -447,7 +440,7 @@ export default function DashboardPage() {
           <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
             <div className="modal-box relative w-full max-w-md">
               <button
-                className="btn btn-sm btn-circle absolute right-2 top-2"
+                className="btn btn-circle btn-md md:btn-sm absolute right-2 top-2"
                 onClick={() => setIsObjectModalOpen(false)}
               >
                 ✕


### PR DESCRIPTION
## Summary
- enlarge interactive areas for hamburger and account buttons
- refine dashboard header layout for better responsiveness
- adjust button sizes to be larger by default and small on medium screens

## Testing
- `npm test`
- `npm run lint` *(fails: Prettier formatting errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689725bcce588324bd134d0a8ca5b344