### PR TITLE
feat: улучшить адаптивное размещение кнопок в карточках

### DIFF
--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -20,17 +20,17 @@ export default function HardwareCard({
         </div>
       </div>
       {isAdmin && (
-        <div className="flex space-x-2">
+        <div className="flex flex-col xs:flex-row md:flex-row gap-2">
           <button
             onClick={onEdit}
-            className="btn btn-sm btn-outline flex items-center gap-1"
+            className="btn btn-sm btn-outline flex items-center gap-1 xs:w-full"
           >
             <PencilIcon className="w-4 h-4" />
             Изменить
           </button>
           <button
             onClick={onDelete}
-            className="btn btn-sm btn-error flex items-center gap-1"
+            className="btn btn-sm btn-error flex items-center gap-1 xs:w-full"
           >
             <TrashIcon className="w-4 h-4" />
             Удалить

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -36,7 +36,7 @@ export default function TaskCard({
 
   return (
     <Card
-      className="flex justify-between items-center cursor-pointer hover:bg-base-200 transition animate-fade-in"
+      className="flex flex-col xs:flex-row md:flex-row justify-between items-start xs:items-center cursor-pointer hover:bg-base-200 transition animate-fade-in"
       onClick={onView}
     >
       <div className="flex-1">
@@ -49,12 +49,12 @@ export default function TaskCard({
           </p>
         )}
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex flex-col xs:flex-row md:flex-row items-center gap-2 mt-2 xs:mt-0">
         <span className={`badge ${badgeClass}`}>{item.status}</span>
         {canManage && (
           <>
             <button
-              className="btn btn-sm btn-ghost"
+              className="btn btn-sm btn-ghost xs:w-full"
               title="Редактировать"
               onClick={(e) => {
                 e.stopPropagation()
@@ -64,7 +64,7 @@ export default function TaskCard({
               <PencilIcon className="w-4 h-4" />
             </button>
             <button
-              className="btn btn-sm btn-ghost"
+              className="btn btn-sm btn-ghost xs:w-full"
               title="Удалить"
               onClick={(e) => {
                 e.stopPropagation()


### PR DESCRIPTION
### Summary
- Сделал кнопочные блоки в HardwareCard и TaskCard вертикальными на мобильных и горизонтальными на больших экранах.
- Добавил `gap-2` между кнопками и `xs:w-full` для полноты ширины на мобильных.
- В TaskCard перенёс статус и иконки под основной текст для компактности.

### Testing
- `npm test`
- `npm run lint` (ошибки форматирования в других файлах)


------
https://chatgpt.com/codex/tasks/task_e_689725be61108324bc8c2878df508089