### PR TITLE
Добавить переключатель темы и плавный переход

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="ru" data-theme="light">
+<html lang="ru" data-theme="light" class="transition-colors duration-300">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Inventory App</title>
   <link rel="stylesheet" href="/src/index.css" />
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 transition-colors duration-300">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react'
+import { SunIcon, MoonIcon } from '@heroicons/react/24/outline'
+
+const THEME_KEY = 'theme'
+const DEFAULT_THEME = 'light'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      return localStorage.getItem(THEME_KEY) || DEFAULT_THEME
+    }
+    return DEFAULT_THEME
+  })
+
+  // Устанавливаем выбранную тему при монтировании и при изменении
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(THEME_KEY, theme)
+    }
+  }, [theme])
+
+  function toggleTheme() {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <button
+      className="btn btn-sm"
+      onClick={toggleTheme}
+      aria-label="Переключить тему"
+    >
+      {theme === 'light' ? (
+        <MoonIcon className="w-4 h-4" />
+      ) : (
+        <SunIcon className="w-4 h-4" />
+      )}
+    </button>
+  )
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -6,6 +6,7 @@ import AccountModal from '../components/AccountModal'
 import ConfirmModal from '../components/ConfirmModal'
 import { toast } from 'react-hot-toast'
 import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline'
+import ThemeToggle from '../components/ThemeToggle'
 import {
   requestNotificationPermission,
   pushNotification,
@@ -154,7 +155,6 @@ export default function DashboardPage() {
       .select('*')
       .order('created_at', { ascending: true })
     if (error) {
-
       if (error.status === 401) {
         await supabase.auth.signOut()
         navigate('/auth')
@@ -199,13 +199,11 @@ export default function DashboardPage() {
         .select()
         .single()
       if (error) {
-
         if (error.status === 403) toast.error('Недостаточно прав')
         else toast.error('Ошибка редактирования: ' + error.message)
 
         await handleSupabaseError(error, navigate, 'Ошибка редактирования')
         return
-
       } else {
         setObjects((prev) =>
           prev.map((o) => (o.id === editingObject.id ? data : o)),
@@ -222,13 +220,11 @@ export default function DashboardPage() {
         .select()
         .single()
       if (error) {
-
         if (error.status === 403) toast.error('Недостаточно прав')
         else toast.error('Ошибка добавления: ' + error.message)
 
         await handleSupabaseError(error, navigate, 'Ошибка добавления')
         return
-
       } else {
         setObjects((prev) => [...prev, data])
         setSelected(data)
@@ -250,13 +246,11 @@ export default function DashboardPage() {
     const id = deleteCandidate
     const { error } = await supabase.from('objects').delete().eq('id', id)
     if (error) {
-
       if (error.status === 403) toast.error('Недостаточно прав')
       else toast.error('Ошибка удаления: ' + error.message)
 
       await handleSupabaseError(error, navigate, 'Ошибка удаления')
       return
-
     } else {
       setObjects((prev) => {
         const updated = prev.filter((o) => o.id !== id)
@@ -415,6 +409,7 @@ export default function DashboardPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              <ThemeToggle />
               <button
                 className="btn btn-sm"
                 onClick={() => setIsAccountModalOpen(true)}


### PR DESCRIPTION
## Изменения
- добавлен компонент `ThemeToggle` с сохранением выбранной темы
- в хедер `DashboardPage` добавлен переключатель темы
- активирован плавный переход цветов через `transition-colors`

## Тестирование
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689725c373f08324b3ebb872bab16ead