### PR TITLE
chore: remove redundant stylesheet link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Inventory App</title>
-
-  <link rel="stylesheet" href="/src/index.css">
-
 </head>
-
 <body class="bg-base-200 w-full min-h-screen transition-colors duration-300">
-
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove unused stylesheet link from HTML since styles are imported via React entry

## Testing
- `npm test` *(fails: Transform failed with errors in AuthPage.jsx and DashboardPage.jsx)*
- `npm run build` *(fails: Transform failed with error in MissingEnvPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689891cf628c8324b0ebcb6795fed290