### PR TITLE
refactor: clean duplicate containers

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -340,11 +340,7 @@ export default function DashboardPage() {
 
   if (!selected) {
     return (
-
-      <div className="flex items-center justify-center h-screen text-base-content/70 transition-colors">
-
       <div className="flex w-full min-h-screen items-center justify-center bg-base-100 text-gray-500">
-
         Загрузка объектов...
       </div>
     )
@@ -352,15 +348,9 @@ export default function DashboardPage() {
 
   return (
     <>
-
       <div className="flex h-screen bg-base-100 transition-colors">
         {/* Десктоп- и мобайл-сайдбар */}
         <aside className="hidden md:flex flex-col w-72 bg-base-200 p-4 border-r shadow-lg overflow-y-auto transition-colors">
-
-      <div className="flex min-h-screen w-full bg-base-100">
-        {/* Десктоп- и мобайл-сайдбар */}
-        <aside className="hidden md:flex flex-col w-72 bg-base-200 p-4 border-r shadow-lg overflow-y-auto">
-
           <InventorySidebar
             objects={objects}
             selected={selected}
@@ -377,27 +367,19 @@ export default function DashboardPage() {
               className="fixed inset-0 bg-black bg-opacity-50"
               onClick={toggleSidebar}
             />
-
             <button
               className="btn btn-circle btn-md md:btn-sm absolute right-4 top-4 z-20"
               onClick={toggleSidebar}
             >
               ✕
             </button>
-            <aside className="relative z-20 w-72 bg-gray-50 p-4 shadow-lg overflow-y-auto">
-
-
             <aside className="relative z-20 w-72 bg-base-200 p-4 shadow-lg overflow-y-auto transition-colors">
-
-            <aside className="relative z-20 w-72 bg-base-200 p-4 shadow-lg overflow-y-auto">
-
               <button
                 className="btn btn-circle btn-md md:btn-sm absolute right-2 top-2"
                 onClick={toggleSidebar}
               >
                 ✕
               </button>
-
               <InventorySidebar
                 objects={objects}
                 selected={selected}


### PR DESCRIPTION
## Summary
- simplify dashboard sidebar layout by removing duplicated div/aside blocks
- ensure loading state has a single container

## Testing
- `npm test` (fails: AuthPage.jsx parse error)
- `npm run build` (fails: Parse error in main.js)


------
https://chatgpt.com/codex/tasks/task_e_68989a41c22c832497ec04380ba6a299