### PR TITLE
fix: remove trailing comma in root render

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,10 +4,11 @@ import App from './App'
 import './index.css'
 import { AuthProvider } from './context/AuthContext'
 
+// prettier-ignore
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
       <App />
     </AuthProvider>
-  </StrictMode>,
-)
+  </StrictMode>
+);


### PR DESCRIPTION
## Summary
- remove extraneous comma so `render` receives only a single JSX argument

## Testing
- `npm test` *(fails: Transform failed with error in MissingEnvPage.jsx)*
- `npm run build` *(fails: Parse error in src/main.js)*

------
https://chatgpt.com/codex/tasks/task_e_68989cf74d288324b9a363c27882c68c