### PR TITLE
fix: удалить дублирование кнопки закрытия мобильного сайдбара

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -367,12 +367,6 @@ export default function DashboardPage() {
               className="fixed inset-0 bg-black bg-opacity-50"
               onClick={toggleSidebar}
             />
-            <button
-              className="btn btn-circle btn-md md:btn-sm absolute right-4 top-4 z-20"
-              onClick={toggleSidebar}
-            >
-              ✕
-            </button>
             <aside className="relative z-20 w-72 bg-base-200 p-4 shadow-lg overflow-y-auto transition-colors">
               <button
                 className="btn btn-circle btn-md md:btn-sm absolute right-2 top-2"


### PR DESCRIPTION
## Summary
- remove duplicated close button in mobile sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c4702b0c8324841817147685ce45