### PR TITLE
feat: style chat bubbles and add timestamps

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -134,22 +134,45 @@ export default function ChatTab({ selected }) {
 
   return (
     <div className="flex flex-col h-full">
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto p-4 space-y-3 bg-base-200 rounded-2xl"
+      >
         {messages.length === 0 ? (
           <div className="text-sm text-gray-400">
             Сообщений пока нет — напиши первым.
           </div>
         ) : (
-          messages.map((m) => (
-            <div key={m.id} className="chat chat-start">
-              <div className="chat-header">{m.sender || 'user'}</div>
-              <div className="chat-bubble whitespace-pre-wrap">{m.content}</div>
-              <div className="chat-footer opacity-50 text-xs">
-                {new Date(m.created_at).toLocaleString()}
-                {m._optimistic ? ' • отправка…' : ''}
+          messages.map((m) => {
+            const isMe = m.sender === 'me'
+            const time = new Date(m.created_at).toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            })
+            return (
+              <div
+                key={m.id}
+                className={`chat ${isMe ? 'chat-end' : 'chat-start'}`}
+              >
+                {!isMe && (
+                  <div className="chat-header">{m.sender || 'user'}</div>
+                )}
+                <div
+                  className={`chat-bubble whitespace-pre-wrap rounded-lg flex flex-col ${
+                    isMe
+                      ? 'bg-primary text-primary-content'
+                      : 'bg-base-100 text-base-content'
+                  }`}
+                >
+                  <span>{m.content}</span>
+                  <span className="self-end mt-1 text-xs opacity-60">
+                    {time}
+                    {m._optimistic ? ' • отправка…' : ''}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))
+            )
+          })
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- polish chat UI with rounded bubbles and sender-specific colors
- show message timestamp inside each bubble
- restyle message container with background and spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c8b548c4832487cc7d244a20adf3