### PR TITLE
feat: align chat messages by sender

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { supabase } from '../supabaseClient'
 import { handleSupabaseError } from '../utils/handleSupabaseError'
 
-export default function ChatTab({ selected }) {
+export default function ChatTab({ selected, userEmail }) {
   const [messages, setMessages] = useState([])
   const [newMessage, setNewMessage] = useState('')
   const [sending, setSending] = useState(false)
@@ -94,7 +94,7 @@ export default function ChatTab({ selected }) {
     const optimistic = {
       id: `tmp-${Date.now()}`,
       object_id: objectId,
-      sender: 'me',
+      sender: userEmail,
       content: newMessage.trim(),
       file_url: null,
       created_at: new Date().toISOString(),
@@ -105,7 +105,7 @@ export default function ChatTab({ selected }) {
     const { error } = await supabase
       .from('chat_messages')
       .insert([
-        { object_id: objectId, sender: 'me', content: newMessage.trim() },
+        { object_id: objectId, sender: userEmail, content: newMessage.trim() },
       ])
 
     if (error) {
@@ -140,16 +140,28 @@ export default function ChatTab({ selected }) {
             Сообщений пока нет — напиши первым.
           </div>
         ) : (
-          messages.map((m) => (
-            <div key={m.id} className="chat chat-start">
-              <div className="chat-header">{m.sender || 'user'}</div>
-              <div className="chat-bubble whitespace-pre-wrap">{m.content}</div>
-              <div className="chat-footer opacity-50 text-xs">
-                {new Date(m.created_at).toLocaleString()}
-                {m._optimistic ? ' • отправка…' : ''}
+          messages.map((m) => {
+            const isOwn = m.sender === userEmail
+            return (
+              <div
+                key={m.id}
+                className={`chat ${isOwn ? 'chat-end' : 'chat-start'}`}
+              >
+                <div className="chat-header">{m.sender || 'user'}</div>
+                <div
+                  className={`chat-bubble whitespace-pre-wrap ${
+                    isOwn ? 'chat-bubble-primary' : ''
+                  }`}
+                >
+                  {m.content}
+                </div>
+                <div className="chat-footer opacity-50 text-xs">
+                  {new Date(m.created_at).toLocaleString()}
+                  {m._optimistic ? ' • отправка…' : ''}
+                </div>
               </div>
-            </div>
-          ))
+            )
+          })
         )}
       </div>
 

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -18,6 +18,7 @@ import { useHardware } from '../hooks/useHardware'
 import { useTasks } from '../hooks/useTasks'
 import { useChatMessages } from '../hooks/useChatMessages'
 import { useObjects } from '../hooks/useObjects'
+import { useAuth } from '../hooks/useAuth'
 import { useNavigate } from 'react-router-dom'
 
 const TAB_KEY = (objectId) => `tab_${objectId}`
@@ -40,11 +41,11 @@ function formatDate(dateStr) {
 export default function InventoryTabs({
   selected,
   onUpdateSelected,
-  user,
   isAdmin = false,
   onTabChange = () => {},
 }) {
   const navigate = useNavigate()
+  const { user } = useAuth()
   // --- вкладки и описание ---
   const [tab, setTab] = useState('desc')
   const [description, setDescription] = useState('')
@@ -1002,7 +1003,11 @@ export default function InventoryTabs({
 
         {/* Чат */}
         {tab === 'chat' && (
-          <ChatTab key={selected?.id} selected={selected} user={user} />
+          <ChatTab
+            key={selected?.id}
+            selected={selected}
+            userEmail={user?.email}
+          />
         )}
       </div>
     </div>

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -401,7 +401,6 @@ export default function DashboardPage() {
             <InventoryTabs
               selected={selected}
               onUpdateSelected={handleUpdateSelected}
-              user={user}
               isAdmin={isAdmin}
               onTabChange={handleTabChange}
             />

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -8,14 +8,14 @@ const { supabaseMock, insertMock, initialMessages } = vi.hoisted(() => {
     {
       id: '1',
       object_id: '1',
-      sender: 'Alice',
+      sender: 'me@example.com',
       content: 'Привет',
       created_at: new Date().toISOString(),
     },
     {
       id: '2',
       object_id: '1',
-      sender: 'Bob',
+      sender: 'other@example.com',
       content: 'Здравствуйте',
       created_at: new Date().toISOString(),
     },
@@ -61,7 +61,7 @@ describe('ChatTab', () => {
   })
 
   it('отображает сообщения и отправляет новое', async () => {
-    render(<ChatTab selected={{ id: '1' }} user={{ email: 'me' }} />)
+    render(<ChatTab selected={{ id: '1' }} userEmail="me@example.com" />)
 
     for (const msg of initialMessages) {
       expect(await screen.findByText(msg.content)).toBeInTheDocument()
@@ -76,5 +76,8 @@ describe('ChatTab', () => {
 
     await waitFor(() => expect(insertMock).toHaveBeenCalled())
     expect(textarea.value).toBe('')
+
+    const myBubble = await screen.findByText('Привет')
+    expect(myBubble.closest('.chat')).toHaveClass('chat-end')
   })
 })


### PR DESCRIPTION
## Summary
- get current user from AuthContext in InventoryTabs
- pass user email to ChatTab and align messages by sender
- test that own messages render at chat-end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c8a98b3883248100619ae1840977