### PR TITLE
Refactor chat bubble styling in ChatTab

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -193,14 +193,7 @@ export default function ChatTab({ selected, userEmail }) {
           </div>
         ) : (
           messages.map((m) => {
-
-            const isOwn = m.sender === userEmail || m.sender === 'me'
-
-
             const isOwn = m.sender === userEmail
-
-            const isMe = m.sender === userEmail
-
 
             const time = new Date(m.created_at).toLocaleTimeString([], {
               hour: '2-digit',
@@ -215,23 +208,14 @@ export default function ChatTab({ selected, userEmail }) {
                   <div className="chat-header">{m.sender || 'user'}</div>
                 )}
                 <div
-
-                  className={`chat-bubble whitespace-pre-wrap flex flex-col ${
-                    isOwn ? 'chat-bubble-primary' : ''
-
                   className={`chat-bubble whitespace-pre-wrap rounded-lg flex flex-col ${
                     isOwn
                       ? 'bg-primary text-primary-content'
                       : 'bg-base-100 text-base-content'
-
                   }`}
                 >
-
                   {m.content && <span>{m.content}</span>}
-
-                  <span>{m.content}</span>
-
-                   {m.file_url && (
+                  {m.file_url && (
                     <div className="mt-2">
                       <AttachmentPreview url={m.file_url} />
                     </div>


### PR DESCRIPTION
## Summary
- simplify chat bubble className with full conditional color styling

## Testing
- `npm test` *(fails: tests/ChatTab.test.jsx > ChatTab > отправляет файл с указанием e-mail отправителя)*

------
https://chatgpt.com/codex/tasks/task_e_6898d21902a48324b6b3f2a58e20f20c