### PR TITLE
refactor: simplify message ownership check

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -193,14 +193,7 @@ export default function ChatTab({ selected, userEmail }) {
           </div>
         ) : (
           messages.map((m) => {
-
-            const isOwn = m.sender === userEmail || m.sender === 'me'
-
-
             const isOwn = m.sender === userEmail
-
-            const isMe = m.sender === userEmail
-
 
             const time = new Date(m.created_at).toLocaleTimeString([], {
               hour: '2-digit',
@@ -215,23 +208,14 @@ export default function ChatTab({ selected, userEmail }) {
                   <div className="chat-header">{m.sender || 'user'}</div>
                 )}
                 <div
-
-                  className={`chat-bubble whitespace-pre-wrap flex flex-col ${
-                    isOwn ? 'chat-bubble-primary' : ''
-
                   className={`chat-bubble whitespace-pre-wrap rounded-lg flex flex-col ${
                     isOwn
                       ? 'bg-primary text-primary-content'
                       : 'bg-base-100 text-base-content'
-
                   }`}
                 >
-
                   {m.content && <span>{m.content}</span>}
-
-                  <span>{m.content}</span>
-
-                   {m.file_url && (
+                  {m.file_url && (
                     <div className="mt-2">
                       <AttachmentPreview url={m.file_url} />
                     </div>

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -88,7 +88,6 @@ describe('ChatTab', () => {
       expect(await screen.findByText(msg.content)).toBeInTheDocument()
     }
 
-
     const firstFooter = (await screen.findByText(initialMessages[0].content))
       .closest('.chat')
       .querySelector('.text-xs')
@@ -105,7 +104,6 @@ describe('ChatTab', () => {
     const otherBubble = await screen.findByText('Здравствуйте')
     expect(otherBubble.closest('.chat')).toHaveClass('chat-start')
 
-
     const textarea = screen.getByPlaceholderText(
       'Напиши сообщение… (Enter — отправить, Shift+Enter — новая строка)',
     )
@@ -119,11 +117,7 @@ describe('ChatTab', () => {
 
   it('отправляет файл с указанием e-mail отправителя', async () => {
     const { container } = render(
-
-      <ChatTab selected={{ id: '1' }} userEmail="me" />,
-
       <ChatTab selected={{ id: '1' }} userEmail="me@example.com" />,
-
     )
 
     const fileInput = container.querySelector('input[type="file"]')


### PR DESCRIPTION
## Summary
- clean up ChatTab message rendering to use single `isOwn` flag
- fix ChatTab test rendering and sender expectation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d213465c83249be2cf57c31f09b5