### PR TITLE
Преобразовать ссылки в чат-сообщениях

### DIFF
--- a/src/components/ChatCard.jsx
+++ b/src/components/ChatCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Card from './Card'
+import { linkifyText } from '../utils/linkify.jsx'
 
 function formatDate(dateStr) {
   if (!dateStr) return ''
@@ -18,7 +19,9 @@ export default function ChatCard({ message }) {
         {message.created_at && ` • ${formatDate(message.created_at)}`}
       </div>
       {message.content && (
-        <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        <p className="whitespace-pre-wrap break-words">
+          {linkifyText(message.content)}
+        </p>
       )}
       {message.file_url && (
         <a

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { supabase } from '../supabaseClient'
 import { handleSupabaseError } from '../utils/handleSupabaseError'
+import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { useChatMessages } from '../hooks/useChatMessages.js'
 
@@ -214,7 +215,11 @@ export default function ChatTab({ selected, userEmail }) {
                       : 'bg-base-100 text-base-content'
                   }`}
                 >
-                  {m.content && <span>{m.content}</span>}
+                  {m.content && (
+                    <span className="whitespace-pre-wrap break-words">
+                      {linkifyText(m.content)}
+                    </span>
+                  )}
                   {m.file_url && (
                     <div className="mt-2">
                       <AttachmentPreview url={m.file_url} />


### PR DESCRIPTION
## Summary
- linkifyText в чатовых компонентах для превращения URL в ссылки
- сохранены классы переноса текста

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898db989140832487a26a618f48b7a0