### PR TITLE
Исправить перенос длинных ссылок в чате

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -208,7 +208,7 @@ export default function ChatTab({ selected, userEmail }) {
                   <div className="chat-header">{m.sender || 'user'}</div>
                 )}
                 <div
-                  className={`chat-bubble whitespace-pre-wrap rounded-lg flex flex-col ${
+                  className={`chat-bubble whitespace-pre-wrap break-words rounded-lg flex flex-col ${
                     isOwn
                       ? 'bg-primary text-primary-content'
                       : 'bg-base-100 text-base-content'


### PR DESCRIPTION
## Summary
- добавить класс `break-words` к пузырю чата для переноса длинных ссылок

## Testing
- `npm test`
- `npm run dev` (проверка визуального переноса ссылок)


------
https://chatgpt.com/codex/tasks/task_e_6898dba5eaac8324a964f3c5356b4b05