### PR TITLE
feat: add profiles table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,20 @@ Inventory App — приложение на React, которое помогае
 6. Старт разработки: `npm run dev`.
 7. Запуск тестов: `npm test`.
 
-### Создание таблицы `profiles`
+### Применение миграции `profiles`
 
-Таблица `profiles` хранит роли пользователей. Создайте её заранее, если выполняете миграции вручную:
+Файл `supabase/migrations/*_create_profiles_table.sql` создаёт таблицу `profiles`,
+функцию `handle_new_user()` и триггер для автоматического добавления записей.
+Чтобы применить миграцию:
 
-```sql
-create table public.profiles (
-  id uuid references auth.users(id) primary key,
-  role text default 'user'
-);
-```
+1. Установите и авторизуйте Supabase CLI.
+2. Выполните в корне проекта:
 
-Без этой таблицы команда `update profiles` из следующего раздела не выполнится.
+   ```bash
+   supabase db push
+   ```
+
+Миграция создаст необходимые объекты в базе.
 
 ### Назначение администраторских прав
 

--- a/supabase/migrations/20250810175341_create_profiles_table.sql
+++ b/supabase/migrations/20250810175341_create_profiles_table.sql
@@ -1,0 +1,19 @@
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id),
+  full_name text,
+  avatar_url text,
+  role text default 'user'
+);
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, full_name, avatar_url)
+  values (new.id, new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'avatar_url');
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();


### PR DESCRIPTION
## Summary
- add SQL migration for profiles table
- document how to run the migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898dc65b5ec8324baf8df73d0127ce0