### PR TITLE
Enable RLS and policies for profiles

### DIFF
--- a/supabase/migrations/20250810120000_enable-profiles-rls.sql
+++ b/supabase/migrations/20250810120000_enable-profiles-rls.sql
@@ -1,0 +1,16 @@
+-- Enable RLS and add policies for profiles table
+alter table profiles enable row level security;
+
+-- Allow users to select their own profile
+create policy "Users can select own profile" on profiles
+  for select using (id = auth.uid());
+
+-- Allow users to update their own profile without changing role
+create policy "Users can update own profile" on profiles
+  for update using (auth.uid() = id)
+  with check (auth.uid() = id and role = (select role from profiles where id = auth.uid()));
+
+-- Allow admins to update role
+create policy "Admins can update role" on profiles
+  for update using (auth.role() = 'admin')
+  with check (auth.role() = 'admin');


### PR DESCRIPTION
## Summary
- enable RLS for profiles table
- add policies for selecting/updating own profile
- allow admins to change user roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898dc692c048324ba598556183de859