### PR TITLE
chore: disable admin role update policy

### DIFF
--- a/supabase/migrations/20250810130000_disable-admin-role-update.sql
+++ b/supabase/migrations/20250810130000_disable-admin-role-update.sql
@@ -1,0 +1,1 @@
+drop policy "Admins can update role" on profiles;


### PR DESCRIPTION
## Summary
- drop `Admins can update role` policy from profiles

## Testing
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e1f140d8832496805d6c7d91edfa