### PR TITLE
Use user auth instead of admin flag for hardware

### DIFF
--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -3,12 +3,7 @@ import React from 'react'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
-export default function HardwareCard({
-  item,
-  onEdit,
-  onDelete,
-  isAdmin = false,
-}) {
+export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
   return (
     <Card className="flex justify-between items-center">
       <div>
@@ -21,7 +16,7 @@ export default function HardwareCard({
           <span>Установка: {item.install_status}</span>
         </div>
       </div>
-      {isAdmin && (
+      {!!user && (
         <div className="flex flex-col xs:flex-row md:flex-row gap-2">
           <button
             onClick={onEdit}

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -639,14 +639,12 @@ export default function InventoryTabs({
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Оборудование</h3>
-              {isAdmin && (
-                <button
-                  className="btn btn-sm btn-primary flex items-center gap-1"
-                  onClick={() => openHWModal()}
-                >
-                  <PlusIcon className="w-4 h-4" /> Добавить
-                </button>
-              )}
+              <button
+                className="btn btn-sm btn-primary flex items-center gap-1"
+                onClick={() => openHWModal()}
+              >
+                <PlusIcon className="w-4 h-4" /> Добавить
+              </button>
             </div>
             {loadingHW && <Spinner />}
             {hardwareError && (
@@ -663,7 +661,7 @@ export default function InventoryTabs({
                     item={h}
                     onEdit={() => openHWModal(h)}
                     onDelete={() => askDeleteHardware(h.id)}
-                    isAdmin={isAdmin}
+                    user={user}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Always show hardware add button
- Use logged-in user to display hardware management actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e47be84483249f7b3e5716b32f37