### PR TITLE
refactor: remove admin gating from object and task actions

### DIFF
--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -9,7 +9,6 @@ export default function InventorySidebar({
   onEdit,
   onDelete,
   notifications = {},
-  isAdmin = false,
 }) {
   return (
     <nav className="flex flex-col space-y-2">
@@ -32,24 +31,22 @@ export default function InventorySidebar({
               </span>
             ) : null}
           </div>
-          {isAdmin && (
-            <>
-              <button
-                onClick={() => onEdit(o)}
-                className="ml-2 text-primary hover:text-primary/70"
-                title="Редактировать объект"
-              >
-                <PencilIcon className="w-4 h-4" />
-              </button>
-              <button
-                onClick={() => onDelete(o.id)}
-                className="ml-2 text-red-500 hover:text-red-700"
-                title="Удалить объект"
-              >
-                <TrashIcon className="w-4 h-4" />
-              </button>
-            </>
-          )}
+          <>
+            <button
+              onClick={() => onEdit(o)}
+              className="ml-2 text-primary hover:text-primary/70"
+              title="Редактировать объект"
+            >
+              <PencilIcon className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => onDelete(o.id)}
+              className="ml-2 text-red-500 hover:text-red-700"
+              title="Удалить объект"
+            >
+              <TrashIcon className="w-4 h-4" />
+            </button>
+          </>
         </Card>
       ))}
     </nav>

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -41,7 +41,6 @@ function formatDate(dateStr) {
 export default function InventoryTabs({
   selected,
   onUpdateSelected,
-  isAdmin = false,
   onTabChange = () => {},
 }) {
   const navigate = useNavigate()
@@ -791,7 +790,7 @@ export default function InventoryTabs({
           <div>
             <div className="flex justify-between mb-4">
               <h3 className="text-xl font-semibold">Задачи</h3>
-              {isAdmin && (
+              {user && (
                 <button
                   className="btn btn-sm btn-primary flex items-center gap-1"
                   onClick={() => openTaskModal()}
@@ -817,7 +816,6 @@ export default function InventoryTabs({
                     onEdit={() => openTaskModal(t)}
                     onDelete={() => askDeleteTask(t.id)}
                     user={user}
-                    isAdmin={isAdmin}
                   />
                 ))}
               </div>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -21,7 +21,6 @@ export default function TaskCard({
   onDelete,
   onView,
   user = {},
-  isAdmin = false,
 }) {
   const badgeClass =
     {
@@ -33,7 +32,6 @@ export default function TaskCard({
   const assignee = item.assignee || item.executor
   const dueDate = item.due_date || item.planned_date || item.plan_date
   const canManage =
-    isAdmin ||
     item.assignee_id === user?.id ||
     item.assignee === user?.user_metadata?.username
 

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -21,7 +21,7 @@ const SELECTED_OBJECT_KEY = 'selectedObjectId'
 const NOTIF_KEY = 'objectNotifications'
 
 export default function DashboardPage() {
-  const { user, isAdmin } = useAuth()
+  const { user } = useAuth()
   const [objects, setObjects] = useState([])
   const [selected, setSelected] = useState(null)
   const [activeTab, setActiveTab] = useState('desc')
@@ -329,7 +329,6 @@ export default function DashboardPage() {
             onEdit={editObject}
             onDelete={askDelete}
             notifications={notifications}
-            isAdmin={isAdmin}
           />
         </aside>
         {isSidebarOpen && (
@@ -352,7 +351,6 @@ export default function DashboardPage() {
                 onEdit={editObject}
                 onDelete={askDelete}
                 notifications={notifications}
-                isAdmin={isAdmin}
               />
             </aside>
           </div>
@@ -366,18 +364,16 @@ export default function DashboardPage() {
               <button className="md:hidden p-2 text-lg" onClick={toggleSidebar}>
                 ☰
               </button>
-              {isAdmin && (
-                <button
-                  className="btn btn-primary btn-md md:btn-sm flex items-center gap-1"
-                  onClick={() => {
-                    setEditingObject(null)
-                    setObjectName('')
-                    setIsObjectModalOpen(true)
-                  }}
-                >
-                  <PlusIcon className="w-4 h-4" /> Добавить
-                </button>
-              )}
+              <button
+                className="btn btn-primary btn-md md:btn-sm flex items-center gap-1"
+                onClick={() => {
+                  setEditingObject(null)
+                  setObjectName('')
+                  setIsObjectModalOpen(true)
+                }}
+              >
+                <PlusIcon className="w-4 h-4" /> Добавить
+              </button>
             </div>
             <div className="flex items-center gap-2">
               <ThemeToggle />
@@ -401,7 +397,6 @@ export default function DashboardPage() {
             <InventoryTabs
               selected={selected}
               onUpdateSelected={handleUpdateSelected}
-              isAdmin={isAdmin}
               onTabChange={handleTabChange}
             />
           </div>

--- a/tests/DashboardPage.test.jsx
+++ b/tests/DashboardPage.test.jsx
@@ -46,7 +46,7 @@ vi.mock('react-hot-toast', () => ({
 }))
 
 vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: {}, isAdmin: false }),
+  useAuth: () => ({ user: {} }),
 }))
 
 import { toast } from 'react-hot-toast'


### PR DESCRIPTION
## Summary
- allow all authenticated users to manage objects and tasks
- simplify DashboardPage by removing isAdmin checks
- adjust tests for updated auth hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e6e3740c8324af9a5237e110b1bb