### PR TITLE
Fix duplicate canManage declaration in TaskCard

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -32,16 +32,9 @@ export default function TaskCard({
   const assignee = item.assignee || item.executor
   const dueDate = item.due_date || item.planned_date || item.plan_date
 
-  const canManage = !!user?.id
-
-
   const canManage =
     item.assignee_id === user?.id ||
     item.assignee === user?.user_metadata?.username
-
-
-  const canManage = !!user?.id
-
 
   return (
     <Card


### PR DESCRIPTION
## Summary
- remove duplicate canManage declarations in TaskCard
- restrict task management buttons to assigned users

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ed7039848324a93beb7ae04ca34a