### PR TITLE
Добавлен аудит действий пользователей

### DIFF
--- a/src/components/AuditTrail.jsx
+++ b/src/components/AuditTrail.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient'
+import Spinner from './Spinner'
+import ErrorMessage from './ErrorMessage'
+
+export default function AuditTrail({ limit = 50 }) {
+  const [logs, setLogs] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('audit_logs')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .limit(limit)
+      if (error) {
+        setError(error)
+        setLogs([])
+      } else {
+        setLogs(data || [])
+        setError(null)
+      }
+      setLoading(false)
+    }
+    load()
+  }, [limit])
+
+  if (loading) return <Spinner />
+  if (error)
+    return <ErrorMessage error={error} message="Ошибка загрузки логов" />
+
+  return (
+    <div className="overflow-auto">
+      <table className="table w-full">
+        <thead>
+          <tr>
+            <th>Время</th>
+            <th>Пользователь</th>
+            <th>Действие</th>
+            <th>Таблица</th>
+            <th>ID</th>
+            <th>Детали</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id}>
+              <td>
+                {log.created_at
+                  ? new Date(log.created_at).toLocaleString('ru-RU')
+                  : ''}
+              </td>
+              <td>{log.user_id}</td>
+              <td>{log.action}</td>
+              <td>{log.target_table}</td>
+              <td>{log.target_id}</td>
+              <td>
+                {log.meta && (
+                  <pre className="whitespace-pre-wrap break-all max-w-xs">
+                    {JSON.stringify(log.meta, null, 2)}
+                  </pre>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/supabase/migrations/20250811000000_create-audit-logs.sql
+++ b/supabase/migrations/20250811000000_create-audit-logs.sql
@@ -1,0 +1,58 @@
+create table if not exists audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  action text not null,
+  target_table text not null,
+  target_id uuid,
+  meta jsonb,
+  created_at timestamptz default now()
+);
+
+create or replace function log_audit_changes()
+returns trigger as $$
+declare
+  v_action text;
+  v_meta jsonb;
+  v_target_id uuid;
+begin
+  if tg_op = 'INSERT' then
+    v_action := 'insert';
+    v_meta := to_jsonb(new);
+    v_target_id := new.id;
+    insert into audit_logs (user_id, action, target_table, target_id, meta)
+    values (auth.uid(), v_action, tg_table_name, v_target_id, v_meta);
+    return new;
+  elsif tg_op = 'UPDATE' then
+    v_action := 'update';
+    v_meta := jsonb_build_object('old', to_jsonb(old), 'new', to_jsonb(new));
+    v_target_id := new.id;
+    insert into audit_logs (user_id, action, target_table, target_id, meta)
+    values (auth.uid(), v_action, tg_table_name, v_target_id, v_meta);
+    return new;
+  elsif tg_op = 'DELETE' then
+    v_action := 'delete';
+    v_meta := to_jsonb(old);
+    v_target_id := old.id;
+    insert into audit_logs (user_id, action, target_table, target_id, meta)
+    values (auth.uid(), v_action, tg_table_name, v_target_id, v_meta);
+    return old;
+  end if;
+  return null;
+end;
+$$ language plpgsql security definer;
+
+create trigger trg_log_tasks
+after insert or update or delete on tasks
+for each row execute function log_audit_changes();
+
+create trigger trg_log_objects
+after insert or update or delete on objects
+for each row execute function log_audit_changes();
+
+create trigger trg_log_hardware
+after insert or update or delete on hardware
+for each row execute function log_audit_changes();
+
+create trigger trg_log_chat_messages
+after insert or update or delete on chat_messages
+for each row execute function log_audit_changes();

--- a/tests/AuditTrail.test.jsx
+++ b/tests/AuditTrail.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import AuditTrail from '../src/components/AuditTrail.jsx'
+
+const { supabaseMock } = vi.hoisted(() => {
+  const logs = [
+    {
+      id: '1',
+      user_id: 'user-1',
+      action: 'insert',
+      target_table: 'tasks',
+      target_id: 't1',
+      meta: { title: 'Test' },
+      created_at: '2024-01-01T00:00:00Z',
+    },
+  ]
+
+  const limitMock = vi.fn(() => Promise.resolve({ data: logs, error: null }))
+  const orderMock = vi.fn(() => ({ limit: limitMock }))
+  const selectMock = vi.fn(() => ({ order: orderMock }))
+  const fromMock = vi.fn(() => ({ select: selectMock }))
+
+  return { supabaseMock: { from: fromMock }, logs }
+})
+
+vi.mock('../src/supabaseClient.js', () => ({ supabase: supabaseMock }))
+
+describe('AuditTrail', () => {
+  it('отображает логи', async () => {
+    render(<AuditTrail limit={10} />)
+    expect(await screen.findByText('insert')).toBeInTheDocument()
+    expect(screen.getByText('tasks')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- добавлена таблица `audit_logs` и универсальный триггер для логирования изменений в ключевых таблицах
- создан компонент `AuditTrail` для просмотра истории действий
- добавлены базовые тесты для нового компонента

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f3929e3083249a360103129c634c