### PR TITLE
feat: allow admins to manage tasks

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -816,7 +816,6 @@ export default function InventoryTabs({
                     onView={() => openTaskView(t)}
                     onEdit={() => openTaskModal(t)}
                     onDelete={() => askDeleteTask(t.id)}
-                    user={user}
                   />
                 ))}
               </div>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { useAuth } from '../hooks/useAuth'
 
 /**
  * Format date string into locale friendly format.
@@ -15,13 +16,8 @@ function formatDate(dateStr) {
   }
 }
 
-export default function TaskCard({
-  item,
-  onEdit,
-  onDelete,
-  onView,
-  user = {},
-}) {
+export default function TaskCard({ item, onEdit, onDelete, onView }) {
+  const { user, isAdmin } = useAuth()
   const badgeClass =
     {
       запланировано: 'badge-info',
@@ -33,6 +29,7 @@ export default function TaskCard({
   const dueDate = item.due_date || item.planned_date || item.plan_date
 
   const canManage =
+    isAdmin ||
     item.assignee_id === user?.id ||
     item.assignee === user?.user_metadata?.username
 

--- a/supabase/migrations/20250812000000_update-task-policies.sql
+++ b/supabase/migrations/20250812000000_update-task-policies.sql
@@ -1,0 +1,29 @@
+-- Update task policies to allow management by admins and assignees
+
+-- Remove existing permissive policies if present
+drop policy if exists "allow_authenticated" on tasks;
+drop policy if exists "Users can update own tasks" on tasks;
+
+-- Allow authenticated users to read and create tasks
+create policy "allow_authenticated_read_tasks" on tasks
+  for select using (auth.role() = 'authenticated');
+
+create policy "allow_authenticated_insert_tasks" on tasks
+  for insert with check (auth.role() = 'authenticated');
+
+-- Allow users to modify only tasks assigned to them
+create policy "Users can update own tasks" on tasks
+  for update using (assignee_id = auth.uid());
+
+create policy "Users can delete own tasks" on tasks
+  for delete using (assignee_id = auth.uid());
+
+-- Allow admins full control over tasks
+create policy "Admins can manage tasks" on tasks
+  for all using (
+    exists (
+      select 1 from profiles p
+      where p.id = auth.uid() and p.role = 'admin'
+    )
+  );
+


### PR DESCRIPTION
## Summary
- allow admins to edit and delete any task
- check auth role instead of passing user to TaskCard
- add Supabase policies for task management

## Testing
- `npm test`
- `npm run lint` *(fails: prettier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6898f76194ec83248a66eca0852119fd