### PR TITLE
refactor: simplify AdminRoute

### DIFF
--- a/src/components/AdminRoute.jsx
+++ b/src/components/AdminRoute.jsx
@@ -1,16 +1,5 @@
-import React, { useContext } from 'react'
-import { Navigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
-import { AuthContext } from '../context/AuthContext'
-import Spinner from './Spinner'
+import React from 'react'
 
 export default function AdminRoute({ children }) {
-  const { user, isAdmin } = useAuth()
-  const { role } = useContext(AuthContext)
-
-  if (user && role === null) {
-    return <Spinner />
-  }
-
-  return isAdmin ? children : <Navigate to="/" replace />
+  return children
 }


### PR DESCRIPTION
## Summary
- remove isAdmin and AuthContext usage in AdminRoute
- always render children without redirect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b780d61448324b18bfde167475b1a