### PR TITLE
feat: always show task management actions

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
-import { useAuth } from '../hooks/useAuth'
 
 /**
  * Format date string into locale friendly format.
@@ -17,7 +16,6 @@ function formatDate(dateStr) {
 }
 
 export default function TaskCard({ item, onEdit, onDelete, onView }) {
-  const { user, isAdmin } = useAuth()
   const badgeClass =
     {
       запланировано: 'badge-info',
@@ -28,10 +26,7 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
   const assignee = item.assignee || item.executor
   const dueDate = item.due_date || item.planned_date || item.plan_date
 
-  const canManage =
-    isAdmin ||
-    item.assignee_id === user?.id ||
-    item.assignee === user?.user_metadata?.username
+  const canManage = true
 
   return (
     <Card


### PR DESCRIPTION
## Summary
- always allow task management actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b780dab20832484107cf7604d0807