### PR TITLE
feat: simplify task policies

### DIFF
--- a/supabase/migrations/20250813090000_authenticated-task-policy.sql
+++ b/supabase/migrations/20250813090000_authenticated-task-policy.sql
@@ -1,0 +1,7 @@
+drop policy if exists "Users can update own tasks" on tasks;
+drop policy if exists "Users can delete own tasks" on tasks;
+drop policy if exists "Admins can manage tasks" on tasks;
+
+create policy "Authenticated users manage tasks" on tasks
+  for all using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary
- allow any authenticated user to manage tasks
- remove old task RLS policies

## Testing
- `npm test`
- verified authenticated vs anon role updates via psql

------
https://chatgpt.com/codex/tasks/task_e_689b780e1eb08324836538351e11fc6e