### PR TITLE
feat: улучшить кнопку вложения в чате

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -4,6 +4,7 @@ import { handleSupabaseError } from '../utils/handleSupabaseError'
 import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { useChatMessages } from '../hooks/useChatMessages.js'
+import { PaperClipIcon } from '@heroicons/react/24/outline'
 
 export default function ChatTab({ selected, userEmail }) {
   const [messages, setMessages] = useState([])
@@ -245,8 +246,12 @@ export default function ChatTab({ selected, userEmail }) {
             htmlFor="chat-file-input"
             className="btn btn-ghost"
             data-testid="file-label"
+            aria-label="Прикрепить файл"
+            title="Прикрепить файл"
+            role="button"
+            tabIndex={0}
           >
-            📎
+            <PaperClipIcon className="w-6 h-6" />
           </label>
           <input
             id="chat-file-input"

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -120,9 +120,15 @@ describe('ChatTab', () => {
       <ChatTab selected={{ id: '1' }} userEmail="me@example.com" />,
     )
 
-    const fileInput = container.querySelector('input[type="file"]')
-    expect(fileInput).toBeInTheDocument()
+    const labelButton = screen.getByRole('button', { name: 'Прикрепить файл' })
+    expect(labelButton).toBeInTheDocument()
 
+    const labelIcon = container.querySelector(
+      'label[data-testid="file-label"] svg',
+    )
+    expect(labelIcon).toBeInTheDocument()
+
+    const fileInput = container.querySelector('input[type="file"]')
     const file = new File(['content'], 'test.txt', { type: 'text/plain' })
     fireEvent.change(fileInput, { target: { files: [file] } })
 


### PR DESCRIPTION
## Summary
- заменить эмодзи скрепки на SVG PaperClip из heroicons
- добавить aria-label и другие атрибуты доступности для кнопки выбора файла
- обновить тесты для проверки иконки и доступности

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7db61de48324836ed86bd29fe1ec