### PR TITLE
fix: improve task card button layout

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -43,12 +43,12 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
           </p>
         )}
       </div>
-      <div className="flex flex-col xs:flex-row md:flex-row items-center gap-2 mt-2 xs:mt-0">
+      <div className="flex flex-col xs:flex-row md:flex-row flex-wrap items-center gap-2 mt-2 xs:mt-0">
         <span className={`badge ${badgeClass}`}>{item.status}</span>
         {canManage && (
           <>
             <button
-              className="btn btn-sm btn-ghost xs:w-full"
+              className="btn btn-sm btn-ghost w-full xs:w-auto"
               title="Редактировать"
               onClick={(e) => {
                 e.stopPropagation()
@@ -58,7 +58,7 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
               <PencilIcon className="w-4 h-4" />
             </button>
             <button
-              className="btn btn-sm btn-ghost xs:w-full"
+              className="btn btn-sm btn-ghost w-full xs:w-auto"
               title="Удалить"
               onClick={(e) => {
                 e.stopPropagation()


### PR DESCRIPTION
## Summary
- ensure TaskCard action buttons use full width on narrow screens
- add flex-wrap to avoid horizontal overflow when wrapping

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7fe86800832498d9225b36b5f1f5