### PR TITLE
feat: add table export and import utilities

### DIFF
--- a/src/utils/exportImport.js
+++ b/src/utils/exportImport.js
@@ -1,0 +1,38 @@
+export async function exportTable(table, format) {
+  try {
+    const res = await fetch(
+      `/api/export/${table}?format=${encodeURIComponent(format)}`,
+    )
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Export failed (${res.status}): ${text}`)
+    }
+    return await res.blob()
+  } catch (err) {
+    console.error('exportTable error:', err)
+    throw err
+  }
+}
+
+export async function importTable(table, file) {
+  const formData = new FormData()
+  formData.append('file', file)
+  try {
+    const res = await fetch(`/api/import/${table}`, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Import failed (${res.status}): ${text}`)
+    }
+    const result = await res.json()
+    return {
+      processedRows: result.processed ?? 0,
+      errors: result.errors ?? [],
+    }
+  } catch (err) {
+    console.error('importTable error:', err)
+    throw err
+  }
+}


### PR DESCRIPTION
## Summary
- add table export and import helpers using fetch
- return processed row counts and errors on import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b80018e4c8324bb5a5ee3526538b5