### PR TITLE
Restrict import/export actions to authorized roles

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -3,5 +3,10 @@ import { AuthContext } from '../context/AuthContext'
 
 export function useAuth() {
   const { user, role } = useContext(AuthContext)
-  return { user, isAdmin: role === 'admin', isUser: role === 'user' }
+  return {
+    user,
+    isAdmin: role === 'admin',
+    isManager: role === 'manager',
+    isUser: role === 'user',
+  }
 }

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -21,7 +21,7 @@ const SELECTED_OBJECT_KEY = 'selectedObjectId'
 const NOTIF_KEY = 'objectNotifications'
 
 export default function DashboardPage() {
-  const { user } = useAuth()
+  const { user, isAdmin, isManager } = useAuth()
   const [objects, setObjects] = useState([])
   const [selected, setSelected] = useState(null)
   const [activeTab, setActiveTab] = useState('desc')
@@ -374,6 +374,22 @@ export default function DashboardPage() {
               >
                 <PlusIcon className="w-4 h-4" /> Добавить
               </button>
+              {(isAdmin || isManager) && (
+                <>
+                  <button
+                    className="btn btn-secondary btn-md md:btn-sm"
+                    onClick={() => {}}
+                  >
+                    Импорт
+                  </button>
+                  <button
+                    className="btn btn-secondary btn-md md:btn-sm"
+                    onClick={() => {}}
+                  >
+                    Экспорт
+                  </button>
+                </>
+              )}
             </div>
             <div className="flex items-center gap-2">
               <ThemeToggle />

--- a/supabase/functions/import-export/index.ts
+++ b/supabase/functions/import-export/index.ts
@@ -1,0 +1,37 @@
+import { serve } from 'std/server'
+import { createClient } from '@supabase/supabase-js'
+
+serve(async (req) => {
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+    {
+      global: {
+        headers: {
+          Authorization: req.headers.get('Authorization') || '',
+        },
+      },
+    },
+  )
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+    })
+  }
+
+  const role = user.app_metadata?.role || user.user_metadata?.role
+  if (!['admin', 'manager'].includes(role)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+    })
+  }
+
+  return new Response(JSON.stringify({ message: 'ok' }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+})


### PR DESCRIPTION
## Summary
- add edge function checking JWT role and allowing only admin or manager
- expose `isManager` via useAuth hook
- show import/export buttons on dashboard only for admin or manager users

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b8002d4e4832483273235cee04217