### PR TITLE
Вынесена логика чата в хук и добавлены тесты

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,179 +1,24 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react'
-import { supabase } from '../supabaseClient'
-import { handleSupabaseError } from '../utils/handleSupabaseError'
+import React from 'react'
 import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
-import { useChatMessages } from '../hooks/useChatMessages.js'
 import { PaperClipIcon } from '@heroicons/react/24/outline'
+import useChat from '../hooks/useChat.js'
 
 export default function ChatTab({ selected, userEmail }) {
-  const [messages, setMessages] = useState([])
-  const [newMessage, setNewMessage] = useState('')
-  const [sending, setSending] = useState(false)
-  const [file, setFile] = useState(null)
-  const [filePreview, setFilePreview] = useState(null)
-  const scrollRef = useRef(null)
-  const channelRef = useRef(null)
-  const fileInputRef = useRef(null)
-  const { sendMessage } = useChatMessages()
-
   const objectId = selected?.id || null
-
-  // Прокрутка вниз при каждом обновлении сообщений
-  useEffect(() => {
-    if (!scrollRef.current) return
-    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-  }, [messages])
-
-  useEffect(() => {
-    if (!file) {
-      setFilePreview(null)
-      return
-    }
-    if (typeof URL.createObjectURL === 'function') {
-      const url = URL.createObjectURL(file)
-      setFilePreview(url)
-      return () => URL.revokeObjectURL && URL.revokeObjectURL(url)
-    }
-  }, [file])
-
-  const loadMessages = useCallback(async () => {
-    if (!objectId) return
-    const { data, error } = await supabase
-      .from('chat_messages')
-      .select('*')
-      .eq('object_id', objectId)
-      .order('created_at', { ascending: true })
-
-    if (error) {
-      await handleSupabaseError(error, null, 'Ошибка загрузки сообщений')
-      return
-    }
-    setMessages(data || [])
-  }, [objectId])
-
-  const markMessagesAsRead = useCallback(async () => {
-    if (!objectId) return
-    await supabase
-      .from('chat_messages')
-      .update({ read_at: new Date().toISOString() })
-      .is('read_at', null)
-      .eq('object_id', objectId)
-      .neq('sender', userEmail)
-  }, [objectId, userEmail])
-
-  // Инициализация: загрузка + подписка на realtime
-  useEffect(() => {
-    // очистка старого канала при смене объекта
-    if (channelRef.current) {
-      supabase.removeChannel(channelRef.current)
-      channelRef.current = null
-    }
-
-    setMessages([])
-    if (!objectId) return
-
-    loadMessages()
-
-    // ВАЖНО: подписка через supabase.channel + postgres_changes (новый API)
-    const ch = supabase
-      .channel(`chat:${objectId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'chat_messages',
-          filter: `object_id=eq.${objectId}`,
-        },
-        (payload) => {
-          if (payload.eventType === 'INSERT') {
-            setMessages((prev) => [...prev, payload.new].sort(sortByCreatedAt))
-          } else if (payload.eventType === 'UPDATE') {
-            setMessages((prev) =>
-              prev
-                .map((m) => (m.id === payload.new.id ? payload.new : m))
-                .sort(sortByCreatedAt),
-            )
-          } else if (payload.eventType === 'DELETE') {
-            setMessages((prev) => prev.filter((m) => m.id !== payload.old.id))
-          }
-        },
-      )
-      .subscribe((status) => {
-        if (status === 'SUBSCRIBED') {
-          // доп. загрузка на всякий, если кэш пустой
-          loadMessages()
-        }
-      })
-
-    channelRef.current = ch
-
-    return () => {
-      if (channelRef.current) {
-        supabase.removeChannel(channelRef.current)
-        channelRef.current = null
-      }
-    }
-  }, [objectId, loadMessages])
-
-  useEffect(() => {
-    markMessagesAsRead()
-  }, [messages, markMessagesAsRead])
-
-  const handleSend = async () => {
-    if (!objectId || (!newMessage.trim() && !file) || sending) return
-    setSending(true)
-
-    if (file) {
-      const { error } = await sendMessage({
-        objectId,
-        sender: userEmail,
-        content: newMessage.trim(),
-        file,
-      })
-      if (error) {
-        await handleSupabaseError(error, null, 'Ошибка отправки')
-      }
-      setFile(null)
-      if (fileInputRef.current) fileInputRef.current.value = ''
-      setNewMessage('')
-      setSending(false)
-      return
-    }
-
-    const optimistic = {
-      id: `tmp-${Date.now()}`,
-      object_id: objectId,
-      sender: userEmail,
-      content: newMessage.trim(),
-      file_url: null,
-      created_at: new Date().toISOString(),
-      _optimistic: true,
-    }
-    setMessages((prev) => [...prev, optimistic])
-
-    const { error } = await supabase
-      .from('chat_messages')
-      .insert([
-        { object_id: objectId, sender: userEmail, content: newMessage.trim() },
-      ])
-
-    if (error) {
-      await handleSupabaseError(error, null, 'Ошибка отправки')
-      // откатываем оптимистичную запись
-      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
-    }
-    setNewMessage('')
-    setSending(false)
-  }
-
-  const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
-  }
+  const {
+    messages,
+    newMessage,
+    setNewMessage,
+    sending,
+    file,
+    setFile,
+    filePreview,
+    handleSend,
+    handleKeyDown,
+    fileInputRef,
+    scrollRef,
+  } = useChat({ objectId, userEmail })
 
   if (!objectId) {
     return (
@@ -280,8 +125,4 @@ export default function ChatTab({ selected, userEmail }) {
       </div>
     </div>
   )
-}
-
-function sortByCreatedAt(a, b) {
-  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
 }

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { supabase } from '../supabaseClient'
+import { handleSupabaseError } from '../utils/handleSupabaseError'
+import { useChatMessages } from './useChatMessages.js'
+
+export default function useChat({ objectId, userEmail }) {
+  const [messages, setMessages] = useState([])
+  const [newMessage, setNewMessage] = useState('')
+  const [sending, setSending] = useState(false)
+  const [file, setFile] = useState(null)
+  const [filePreview, setFilePreview] = useState(null)
+  const scrollRef = useRef(null)
+  const channelRef = useRef(null)
+  const fileInputRef = useRef(null)
+  const { sendMessage } = useChatMessages()
+
+  const loadMessages = useCallback(async () => {
+    if (!objectId) return
+    const { data, error } = await supabase
+      .from('chat_messages')
+      .select('*')
+      .eq('object_id', objectId)
+      .order('created_at', { ascending: true })
+
+    if (error) {
+      await handleSupabaseError(error, null, 'Ошибка загрузки сообщений')
+      return
+    }
+    setMessages(data || [])
+  }, [objectId])
+
+  const markMessagesAsRead = useCallback(async () => {
+    if (!objectId) return
+    await supabase
+      .from('chat_messages')
+      .update({ read_at: new Date().toISOString() })
+      .is('read_at', null)
+      .eq('object_id', objectId)
+      .neq('sender', userEmail)
+  }, [objectId, userEmail])
+
+  useEffect(() => {
+    if (!scrollRef.current) return
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  }, [messages])
+
+  useEffect(() => {
+    if (!file) {
+      setFilePreview(null)
+      return
+    }
+    if (typeof URL.createObjectURL === 'function') {
+      const url = URL.createObjectURL(file)
+      setFilePreview(url)
+      return () => URL.revokeObjectURL && URL.revokeObjectURL(url)
+    }
+  }, [file])
+
+  useEffect(() => {
+    if (channelRef.current) {
+      supabase.removeChannel(channelRef.current)
+      channelRef.current = null
+    }
+
+    setMessages([])
+    if (!objectId) return
+
+    loadMessages()
+
+    const ch = supabase
+      .channel(`chat:${objectId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'chat_messages',
+          filter: `object_id=eq.${objectId}`,
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT') {
+            setMessages((prev) => [...prev, payload.new].sort(sortByCreatedAt))
+          } else if (payload.eventType === 'UPDATE') {
+            setMessages((prev) =>
+              prev
+                .map((m) => (m.id === payload.new.id ? payload.new : m))
+                .sort(sortByCreatedAt),
+            )
+          } else if (payload.eventType === 'DELETE') {
+            setMessages((prev) => prev.filter((m) => m.id !== payload.old.id))
+          }
+        },
+      )
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          loadMessages()
+        }
+      })
+
+    channelRef.current = ch
+
+    return () => {
+      if (channelRef.current) {
+        supabase.removeChannel(channelRef.current)
+        channelRef.current = null
+      }
+    }
+  }, [objectId, loadMessages])
+
+  useEffect(() => {
+    markMessagesAsRead()
+  }, [messages, markMessagesAsRead])
+
+  const handleSend = async () => {
+    if (!objectId || (!newMessage.trim() && !file) || sending) return
+    setSending(true)
+
+    if (file) {
+      const { error } = await sendMessage({
+        objectId,
+        sender: userEmail,
+        content: newMessage.trim(),
+        file,
+      })
+      if (error) {
+        await handleSupabaseError(error, null, 'Ошибка отправки')
+      }
+      setFile(null)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      setNewMessage('')
+      setSending(false)
+      return
+    }
+
+    const optimistic = {
+      id: `tmp-${Date.now()}`,
+      object_id: objectId,
+      sender: userEmail,
+      content: newMessage.trim(),
+      file_url: null,
+      created_at: new Date().toISOString(),
+      _optimistic: true,
+    }
+    setMessages((prev) => [...prev, optimistic])
+
+    const { error } = await supabase
+      .from('chat_messages')
+      .insert([
+        { object_id: objectId, sender: userEmail, content: newMessage.trim() },
+      ])
+
+    if (error) {
+      await handleSupabaseError(error, null, 'Ошибка отправки')
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
+    }
+    setNewMessage('')
+    setSending(false)
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  return {
+    messages,
+    newMessage,
+    setNewMessage,
+    sending,
+    file,
+    setFile,
+    filePreview,
+    handleSend,
+    handleKeyDown,
+    fileInputRef,
+    scrollRef,
+  }
+}
+
+function sortByCreatedAt(a, b) {
+  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+}

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -1,0 +1,142 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import useChat from '../src/hooks/useChat.js'
+
+const {
+  supabaseMock,
+  insertMock,
+  initialMessages,
+  sendMessageMock,
+  selectMock,
+} = vi.hoisted(() => {
+  const initialMessages = [
+    {
+      id: '1',
+      object_id: '1',
+      sender: 'me@example.com',
+      content: 'Привет',
+      created_at: new Date().toISOString(),
+      read_at: new Date().toISOString(),
+    },
+    {
+      id: '2',
+      object_id: '1',
+      sender: 'other@example.com',
+      content: 'Здравствуйте',
+      created_at: new Date().toISOString(),
+    },
+  ]
+
+  const selectMock = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      order: vi.fn(() =>
+        Promise.resolve({ data: initialMessages, error: null }),
+      ),
+    })),
+  }))
+
+  const insertMock = vi.fn(() =>
+    Promise.resolve({ data: { id: '3' }, error: null }),
+  )
+
+  const updateMock = vi.fn(() => ({
+    is: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        neq: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      })),
+    })),
+  }))
+
+  const fromMock = vi.fn(() => ({
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+  }))
+
+  const channelMock = vi.fn(() => ({
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn((cb) => {
+      cb && cb('SUBSCRIBED')
+    }),
+  }))
+
+  const removeChannelMock = vi.fn()
+
+  const supabaseMock = {
+    from: fromMock,
+    channel: channelMock,
+    removeChannel: removeChannelMock,
+  }
+
+  const sendMessageMock = vi.fn(() =>
+    Promise.resolve({ data: { id: '4' }, error: null }),
+  )
+
+  return {
+    supabaseMock,
+    insertMock,
+    initialMessages,
+    sendMessageMock,
+    selectMock,
+  }
+})
+
+vi.mock('../src/supabaseClient.js', () => ({ supabase: supabaseMock }))
+vi.mock('../src/hooks/useChatMessages.js', () => ({
+  useChatMessages: () => ({ sendMessage: sendMessageMock }),
+}))
+vi.mock('../src/utils/handleSupabaseError', () => ({
+  handleSupabaseError: vi.fn(),
+}))
+
+describe('useChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:preview')
+    globalThis.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('загружает сообщения при инициализации', async () => {
+    const { result } = renderHook(() =>
+      useChat({ objectId: '1', userEmail: 'me@example.com' }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.messages).toEqual(initialMessages),
+    )
+    expect(selectMock).toHaveBeenCalled()
+  })
+
+  it('отправляет текстовое сообщение', async () => {
+    const { result } = renderHook(() =>
+      useChat({ objectId: '1', userEmail: 'me@example.com' }),
+    )
+
+    await act(async () => {
+      result.current.setNewMessage('Новое')
+    })
+    await act(async () => {
+      await result.current.handleSend()
+    })
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalled())
+    expect(result.current.newMessage).toBe('')
+  })
+
+  it('отправляет файл', async () => {
+    const { result } = renderHook(() =>
+      useChat({ objectId: '1', userEmail: 'me@example.com' }),
+    )
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+
+    await act(async () => {
+      result.current.setFile(file)
+    })
+    await act(async () => {
+      await result.current.handleSend()
+    })
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalled())
+    expect(result.current.file).toBe(null)
+  })
+})


### PR DESCRIPTION
## Описание
- создан хук `useChat` со всей логикой загрузки, подписки и отправки сообщений
- компонент `ChatTab` упрощён до UI и вызовов хука
- добавлены модульные тесты для нового хука

## Тестирование
- `npm test` *(падает: Failed to parse source for import analysis...)*
- `npx vitest run tests/useChat.test.jsx`
- `npx vitest run tests/ChatTab.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689b8357f6c08324b98ae47050135bf6