### PR TITLE
docs: add OpenAPI docs for import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Inventory App — приложение на React, которое помогае
 
 ### Эндпоинты
 
-- `POST /api/import/:table` — загрузка файла CSV/XLSX и добавление записей в таблицу `objects`, `hardware`, `tasks` или `chat_messages`.
-- `GET /api/export/:table?format=csv|xlsx` — выгрузка содержимого таблицы в выбранном формате.
+- `POST /functions/v1/import` — загрузка файла CSV/XLSX и добавление записей в таблицу `objects`, `hardware`, `tasks` или `chat_messages`.
+- `GET /functions/v1/export/{table}/{format}` — выгрузка содержимого таблицы в формате `csv` или `xlsx`.
 
 ### Поддерживаемые форматы
 
@@ -118,6 +118,24 @@ object_id,name,location,purchase_status,install_status
 ```
 
 В файле XLSX используется такой же набор столбцов на первом листе.
+
+### Примеры запросов
+
+```bash
+# Экспорт CSV
+curl -L -H "Authorization: Bearer <TOKEN>" \
+  https://PROJECT.supabase.co/functions/v1/export/tasks/csv -o tasks.csv
+
+# Экспорт XLSX
+curl -L -H "Authorization: Bearer <TOKEN>" \
+  https://PROJECT.supabase.co/functions/v1/export/tasks/xlsx -o tasks.xlsx
+
+# Импорт CSV
+curl -L -X POST \
+  -F table=tasks \
+  -F file=@tasks.csv \
+  https://PROJECT.supabase.co/functions/v1/import
+```
 
 ## CI
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <title>API Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: './openapi.yaml',
+      dom_id: '#swagger-ui'
+    });
+  </script>
+</body>
+</html>

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,149 @@
+openapi: 3.0.3
+info:
+  title: Inventory App Edge Functions API
+  version: 1.0.0
+servers:
+  - url: https://{project}.supabase.co/functions/v1
+    variables:
+      project:
+        default: YOUR_PROJECT_REF
+paths:
+  /export/{table}/{format}:
+    get:
+      summary: Export table data
+      description: |
+        Download the contents of a table in CSV or XLSX format.
+
+        **CSV example**
+        ```bash
+        curl -L -H "Authorization: Bearer <TOKEN>" \\
+          https://{project}.supabase.co/functions/v1/export/tasks/csv -o tasks.csv
+        ```
+
+        **XLSX example**
+        ```bash
+        curl -L -H "Authorization: Bearer <TOKEN>" \\
+          https://{project}.supabase.co/functions/v1/export/tasks/xlsx -o tasks.xlsx
+        ```
+      parameters:
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Target table name.
+        - name: format
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [csv, xlsx]
+          description: Output format.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Exported file
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /import:
+    post:
+      summary: Import table data
+      description: |
+        Upload a CSV or XLSX file and insert its rows into the specified table.
+
+        **Upload example**
+        ```bash
+        curl -L -X POST \\
+          -F table=tasks \\
+          -F file=@tasks.csv \\
+          https://{project}.supabase.co/functions/v1/import
+        ```
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - table
+                - file
+              properties:
+                table:
+                  type: string
+                  description: Target table name.
+                file:
+                  type: string
+                  format: binary
+                  description: CSV or XLSX file.
+      responses:
+        '200':
+          description: Import result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '405':
+          description: Method not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+    ImportResponse:
+      type: object
+      properties:
+        inserted:
+          type: integer
+          description: Number of successfully inserted rows.
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              row:
+                type: integer
+              error:
+                type: string


### PR DESCRIPTION
## Summary
- add OpenAPI spec and Swagger UI page for Supabase Edge Functions
- document import/export endpoints with examples in README

## Testing
- `npm test` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax)*
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may only appear at the top level)*

------
https://chatgpt.com/codex/tasks/task_e_689b861083248324be462ccc34912603