### PR TITLE
feat: add indexes for tasks, hardware, chat_messages

### DIFF
--- a/supabase/migrations/20250814000000_add-indexes.sql
+++ b/supabase/migrations/20250814000000_add-indexes.sql
@@ -1,0 +1,7 @@
+create index tasks_object_id_idx on tasks(object_id);
+create index tasks_assignee_idx on tasks(assignee);
+create index tasks_created_at_idx on tasks(created_at);
+create index hardware_object_id_idx on hardware(object_id);
+create index hardware_created_at_idx on hardware(created_at);
+create index chat_messages_object_id_idx on chat_messages(object_id);
+create index chat_messages_created_at_idx on chat_messages(created_at);


### PR DESCRIPTION
## Summary
- add indexes for tasks.object_id, tasks.assignee, tasks.created_at
- add indexes for hardware and chat_messages on object_id and created_at

## Testing
- `npm test` *(fails: Vitest cannot be imported in a CommonJS module)*
- `npx supabase migration up` *(fails: connection to local database refused)*
- `npx supabase start` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_689cc81d81c08324838a080406468c6b