### PR TITLE
feat: enable lazy loading for routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,31 +1,37 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
-import AuthPage from './pages/AuthPage'
-import DashboardPage from './pages/DashboardPage'
-import MissingEnvPage from './pages/MissingEnvPage'
+const AuthPage = React.lazy(() => import('./pages/AuthPage'))
+const DashboardPage = React.lazy(() => import('./pages/DashboardPage'))
+const MissingEnvPage = React.lazy(() => import('./pages/MissingEnvPage'))
 import { isSupabaseConfigured } from './supabaseClient'
 import PrivateRoute from './components/PrivateRoute'
 
 export default function App() {
   if (!isSupabaseConfigured) {
-    return <MissingEnvPage />
+    return (
+      <React.Suspense fallback={<div>Загрузка...</div>}>
+        <MissingEnvPage />
+      </React.Suspense>
+    )
   }
 
   return (
     <BrowserRouter>
       <Toaster position="top-right" />
-      <Routes>
-        <Route path="/auth" element={<AuthPage />} />
-        <Route
-          path="/*"
-          element={
-            <PrivateRoute>
-              <DashboardPage />
-            </PrivateRoute>
-          }
-        />
-      </Routes>
+      <React.Suspense fallback={<div>Загрузка...</div>}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage />} />
+          <Route
+            path="/*"
+            element={
+              <PrivateRoute>
+                <DashboardPage />
+              </PrivateRoute>
+            }
+          />
+        </Routes>
+      </React.Suspense>
     </BrowserRouter>
   )
 }

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -37,9 +37,10 @@ jest.mock('react-hot-toast', () => ({
 import App from '@/App'
 
 describe('App', () => {
-  it('отображает страницу авторизации по /auth', async () => {
+  it('отображает индикатор загрузки и страницу авторизации по /auth', async () => {
     window.history.pushState({}, '', '/auth')
     render(<App />)
+    expect(screen.getByText('Загрузка...')).toBeInTheDocument()
     expect(await screen.findByText('Вход')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- load pages lazily with React.lazy
- wrap routes with React.Suspense and loading fallback
- test lazy-loading route behavior

## Testing
- `npm test` *(fails: Vitest cannot be imported in a CommonJS module using require())*
- `npm test tests/App.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689cc81f51848324a835806901cd4e0f