### PR TITLE
Оптимизация ререндеров тяжелых компонентов

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import { memo, useCallback } from 'react'
 import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { PaperClipIcon } from '@heroicons/react/24/outline'
 import useChat from '../hooks/useChat.js'
 
-export default function ChatTab({ selected, userEmail }) {
+function ChatTab({ selected, userEmail }) {
   const objectId = selected?.id || null
   const {
     messages,
@@ -19,6 +19,16 @@ export default function ChatTab({ selected, userEmail }) {
     fileInputRef,
     scrollRef,
   } = useChat({ objectId, userEmail })
+
+  const handleFileChange = useCallback(
+    (e) => setFile(e.target.files[0]),
+    [setFile],
+  )
+
+  const handleMessageChange = useCallback(
+    (e) => setNewMessage(e.target.value),
+    [setNewMessage],
+  )
 
   if (!objectId) {
     return (
@@ -103,13 +113,13 @@ export default function ChatTab({ selected, userEmail }) {
             type="file"
             className="hidden"
             ref={fileInputRef}
-            onChange={(e) => setFile(e.target.files[0])}
+            onChange={handleFileChange}
           />
           <textarea
             className="textarea textarea-bordered w-full min-h-24"
             placeholder="Напиши сообщение… (Enter — отправить, Shift+Enter — новая строка)"
             value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
+            onChange={handleMessageChange}
             onKeyDown={handleKeyDown}
           />
         </div>
@@ -126,3 +136,5 @@ export default function ChatTab({ selected, userEmail }) {
     </div>
   )
 }
+
+export default memo(ChatTab)

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import { memo, useMemo } from 'react'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
-export default function InventorySidebar({
+function InventorySidebar({
   objects,
   selected,
   onSelect,
@@ -10,13 +10,24 @@ export default function InventorySidebar({
   onDelete,
   notifications = {},
 }) {
+  const items = useMemo(
+    () =>
+      objects.map((o) => ({
+        ...o,
+        select: () => onSelect(o),
+        edit: () => onEdit(o),
+        remove: () => onDelete(o.id),
+      })),
+    [objects, onSelect, onEdit, onDelete],
+  )
+
   return (
     <nav className="flex flex-col space-y-2">
-      {objects.map((o) => (
+      {items.map((o) => (
         <Card key={o.id} className="flex items-center justify-between p-2">
           <div className="flex items-center flex-1">
             <button
-              onClick={() => onSelect(o)}
+              onClick={o.select}
               className={`flex-1 text-left px-3 py-2 rounded hover:bg-primary/10 ${
                 selected?.id === o.id
                   ? 'border-b-2 border-primary font-medium'
@@ -33,14 +44,14 @@ export default function InventorySidebar({
           </div>
           <>
             <button
-              onClick={() => onEdit(o)}
+              onClick={o.edit}
               className="ml-2 text-primary hover:text-primary/70"
               title="Редактировать объект"
             >
               <PencilIcon className="w-4 h-4" />
             </button>
             <button
-              onClick={() => onDelete(o.id)}
+              onClick={o.remove}
               className="ml-2 text-red-500 hover:text-red-700"
               title="Удалить объект"
             >
@@ -52,3 +63,5 @@ export default function InventorySidebar({
     </nav>
   )
 }
+
+export default memo(InventorySidebar)

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -38,17 +38,18 @@ function formatDate(dateStr) {
   }
 }
 
-export default function InventoryTabs({
-  selected,
-  onUpdateSelected,
-  onTabChange = () => {},
-}) {
+function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
   const navigate = useNavigate()
   const { user } = useAuth()
   // --- вкладки и описание ---
   const [tab, setTab] = useState('desc')
   const [description, setDescription] = useState('')
   const [isEditingDesc, setIsEditingDesc] = useState(false)
+
+  const showDesc = useCallback(() => setTab('desc'), [])
+  const showHW = useCallback(() => setTab('hw'), [])
+  const showTasks = useCallback(() => setTab('tasks'), [])
+  const showChat = useCallback(() => setTab('chat'), [])
 
   // --- оборудование ---
   const [hardware, setHardware] = useState([])
@@ -621,25 +622,25 @@ export default function InventoryTabs({
       <div className="flex mb-4 border-b">
         <button
           className={`px-4 py-2 hover:bg-primary/10 ${tab === 'desc' ? 'border-b-2 border-primary' : ''}`}
-          onClick={() => setTab('desc')}
+          onClick={showDesc}
         >
           Описание
         </button>
         <button
           className={`px-4 py-2 hover:bg-primary/10 ${tab === 'hw' ? 'border-b-2 border-primary' : ''}`}
-          onClick={() => setTab('hw')}
+          onClick={showHW}
         >
           Железо ({hardware.length})
         </button>
         <button
           className={`px-4 py-2 hover:bg-primary/10 ${tab === 'tasks' ? 'border-b-2 border-primary' : ''}`}
-          onClick={() => setTab('tasks')}
+          onClick={showTasks}
         >
           Задачи ({tasks.length})
         </button>
         <button
           className={`px-4 py-2 hover:bg-primary/10 flex items-center gap-1 ${tab === 'chat' ? 'border-b-2 border-primary' : ''}`}
-          onClick={() => setTab('chat')}
+          onClick={showChat}
         >
           <ChatBubbleOvalLeftIcon className="w-4 h-4" /> Чат (
           {chatMessages.length})
@@ -1126,3 +1127,5 @@ export default function InventoryTabs({
     </div>
   )
 }
+
+export default React.memo(InventoryTabs)

--- a/src/components/ObjectCard.jsx
+++ b/src/components/ObjectCard.jsx
@@ -1,6 +1,7 @@
+import { memo } from 'react'
 import Card from './Card'
 
-export default function ObjectCard({ item }) {
+function ObjectCard({ item }) {
   return (
     <Card>
       <h4 className="font-semibold">{item.name}</h4>
@@ -10,3 +11,5 @@ export default function ObjectCard({ item }) {
     </Card>
   )
 }
+
+export default memo(ObjectCard)

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { memo, useMemo, useCallback } from 'react'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
@@ -15,16 +15,42 @@ function formatDate(dateStr) {
   }
 }
 
-export default function TaskCard({ item, onEdit, onDelete, onView }) {
-  const badgeClass =
-    {
-      запланировано: 'badge-info',
-      'в процессе': 'badge-warning',
-      завершено: 'badge-success',
-    }[item.status] || 'badge'
+function TaskCard({ item, onEdit, onDelete, onView }) {
+  const badgeClass = useMemo(
+    () =>
+      ({
+        запланировано: 'badge-info',
+        'в процессе': 'badge-warning',
+        завершено: 'badge-success',
+      })[item.status] || 'badge',
+    [item.status],
+  )
 
-  const assignee = item.assignee || item.executor
-  const dueDate = item.due_date || item.planned_date || item.plan_date
+  const assignee = useMemo(
+    () => item.assignee || item.executor,
+    [item.assignee, item.executor],
+  )
+
+  const dueDate = useMemo(
+    () => item.due_date || item.planned_date || item.plan_date,
+    [item.due_date, item.planned_date, item.plan_date],
+  )
+
+  const handleEdit = useCallback(
+    (e) => {
+      e.stopPropagation()
+      onEdit()
+    },
+    [onEdit],
+  )
+
+  const handleDelete = useCallback(
+    (e) => {
+      e.stopPropagation()
+      onDelete()
+    },
+    [onDelete],
+  )
 
   const canManage = true
 
@@ -50,20 +76,14 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
             <button
               className="btn btn-sm btn-ghost w-full xs:w-auto"
               title="Редактировать"
-              onClick={(e) => {
-                e.stopPropagation()
-                onEdit()
-              }}
+              onClick={handleEdit}
             >
               <PencilIcon className="w-4 h-4" />
             </button>
             <button
               className="btn btn-sm btn-ghost w-full xs:w-auto"
               title="Удалить"
-              onClick={(e) => {
-                e.stopPropagation()
-                onDelete()
-              }}
+              onClick={handleDelete}
             >
               <TrashIcon className="w-4 h-4" />
             </button>
@@ -73,3 +93,5 @@ export default function TaskCard({ item, onEdit, onDelete, onView }) {
     </Card>
   )
 }
+
+export default memo(TaskCard)


### PR DESCRIPTION
## Изменения
- Обернул ObjectCard, TaskCard, InventorySidebar, ChatTab и InventoryTabs в `React.memo`
- Мемоизировал вычисления и обработчики через `useMemo` и `useCallback`

## Тестирование
- `npm test` *(1 test failed: Vitest cannot be imported in a CommonJS module using require())*

------
https://chatgpt.com/codex/tasks/task_e_689cc8207158832497ee643b575bf32f