### PR TITLE
feat(export): stream table export

### DIFF
--- a/supabase/functions/export/index.ts
+++ b/supabase/functions/export/index.ts
@@ -1,7 +1,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { unparse } from 'https://esm.sh/papaparse@5.4.1'
-import XLSX from 'https://esm.sh/xlsx@0.18.5'
+import ExcelJS from 'https://esm.sh/exceljs@4?target=deno'
 
 serve(async (req: Request) => {
   const url = new URL(req.url)
@@ -12,6 +12,13 @@ serve(async (req: Request) => {
   }
   const table = segments[1]
   const format = segments[2]
+
+  const columnsParam = url.searchParams.get('columns')
+  const selectedColumns = columnsParam?.split(',')
+  const filters: Record<string, string> = {}
+  url.searchParams.forEach((value, key) => {
+    if (key !== 'columns') filters[key] = value
+  })
 
   const authHeader = req.headers.get('Authorization') || ''
   const token = authHeader.replace('Bearer ', '')
@@ -33,14 +40,41 @@ serve(async (req: Request) => {
     return new Response('Forbidden', { status: 403 })
   }
 
-  const { data, error } = await supabase.from(table).select('*')
-  if (error) {
-    return new Response(error.message, { status: 400 })
-  }
-
   if (format === 'csv') {
-    const csv = unparse(data ?? [])
-    return new Response(csv, {
+    const batchSize = 1000
+    let start = 0
+    let firstChunk = true
+    let header: string[] | undefined = selectedColumns
+    const encoder = new TextEncoder()
+
+    const stream = new ReadableStream({
+      async pull(controller) {
+        let query = supabase
+          .from(table)
+          .select(selectedColumns?.join(',') || '*')
+        Object.entries(filters).forEach(([key, value]) => {
+          query = query.eq(key, value)
+        })
+        const { data, error } = await query.range(start, start + batchSize - 1)
+        if (error) {
+          controller.error(error)
+          return
+        }
+        if (!data || data.length === 0) {
+          controller.close()
+          return
+        }
+        if (!header && data.length) {
+          header = Object.keys(data[0])
+        }
+        const csv = unparse(data, { header: firstChunk, columns: header })
+        controller.enqueue(encoder.encode(csv + '\n'))
+        firstChunk = false
+        start += batchSize
+      },
+    })
+
+    return new Response(stream, {
       headers: {
         'Content-Type': 'text/csv',
         'Content-Disposition': `attachment; filename="${table}.csv"`,
@@ -49,11 +83,38 @@ serve(async (req: Request) => {
   }
 
   if (format === 'xlsx') {
-    const worksheet = XLSX.utils.json_to_sheet(data ?? [])
-    const workbook = XLSX.utils.book_new()
-    XLSX.utils.book_append_sheet(workbook, worksheet, table)
-    const xlsx = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' })
-    return new Response(xlsx, {
+    const batchSize = 1000
+    const { readable, writable } = new TransformStream()
+
+    ;(async () => {
+      const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+        stream: writable,
+      })
+      const worksheet = workbook.addWorksheet(table)
+      if (selectedColumns) {
+        worksheet.columns = selectedColumns.map((c) => ({ header: c, key: c }))
+      }
+      let start = 0
+      while (true) {
+        let query = supabase
+          .from(table)
+          .select(selectedColumns?.join(',') || '*')
+        Object.entries(filters).forEach(([key, value]) => {
+          query = query.eq(key, value)
+        })
+        const { data, error } = await query.range(start, start + batchSize - 1)
+        if (error) {
+          writable.abort(error)
+          return
+        }
+        if (!data || data.length === 0) break
+        data.forEach((row) => worksheet.addRow(row).commit())
+        start += batchSize
+      }
+      await workbook.commit()
+    })()
+
+    return new Response(readable, {
       headers: {
         'Content-Type':
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',


### PR DESCRIPTION
## Summary
- stream CSV/XLSX exports in batches
- allow column selection and filters via query params

## Testing
- `npm test` *(fails: Vitest cannot be imported in a CommonJS module using require())*

------
https://chatgpt.com/codex/tasks/task_e_689cc823e52c8324bf9bb825faf40bbf