### PR TITLE
feat: add admin route guard

### DIFF
--- a/src/components/AdminRoute.jsx
+++ b/src/components/AdminRoute.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
 
 export default function AdminRoute({ children }) {
-  return children
+  const { isAdmin } = useAuth()
+  return isAdmin ? children : <Navigate to="/auth" replace />
 }

--- a/tests/AdminRoute.test.jsx
+++ b/tests/AdminRoute.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth.js'
+import AdminRoute from '@/components/AdminRoute.jsx'
+
+jest.mock('@/hooks/useAuth.js', () => ({
+  useAuth: jest.fn(),
+}))
+
+describe('AdminRoute', () => {
+  it('перенаправляет неадминистратора на страницу входа', () => {
+    useAuth.mockReturnValue({ isAdmin: false })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <AdminRoute>
+                <div>Секрет</div>
+              </AdminRoute>
+            }
+          />
+          <Route path="/auth" element={<div>Вход</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Вход')).toBeInTheDocument()
+  })
+
+  it('показывает содержимое администраторам', () => {
+    useAuth.mockReturnValue({ isAdmin: true })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <AdminRoute>
+                <div>Секрет</div>
+              </AdminRoute>
+            }
+          />
+          <Route path="/auth" element={<div>Вход</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Секрет')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- restrict admin-only routes with `AdminRoute`
- add tests for admin access

## Testing
- `npx jest --config jest.config.js`
- `npx jest --config jest.config.js tests/AdminRoute.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689cd65361c08324a652ec560d1d894d