### PR TITLE
Обработка ошибок получения роли и тест

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -13,7 +13,10 @@ export function AuthProvider({ children }) {
 
     const fetchRole = async (id) => {
       const res = await fetch(`/functions/v1/cacheGet?table=profiles&id=${id}`)
-      if (!res.ok) return null
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(text)
+      }
       const body = await res.json()
       return body.data?.role ?? null
     }
@@ -26,7 +29,12 @@ export function AuthProvider({ children }) {
       setUser(currentUser)
 
       if (currentUser) {
-        setRole(await fetchRole(currentUser.id))
+        try {
+          setRole(await fetchRole(currentUser.id))
+        } catch (error) {
+          console.error('Ошибка получения роли:', error)
+          setRole(null)
+        }
       } else {
         setRole(null)
       }
@@ -40,7 +48,12 @@ export function AuthProvider({ children }) {
       const currentUser = session?.user ?? null
       setUser(currentUser)
       if (currentUser) {
-        setRole(await fetchRole(currentUser.id))
+        try {
+          setRole(await fetchRole(currentUser.id))
+        } catch (error) {
+          console.error('Ошибка получения роли:', error)
+          setRole(null)
+        }
       } else {
         setRole(null)
       }

--- a/tests/AuthContext.test.jsx
+++ b/tests/AuthContext.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, jest } from '@jest/globals'
+import { useContext } from 'react'
+import { AuthProvider, AuthContext } from '../src/context/AuthContext.jsx'
+
+const mockGetSession = jest.fn()
+const mockOnAuthStateChange = jest.fn()
+
+jest.mock('../src/supabaseClient.js', () => ({
+  supabase: {
+    auth: {
+      getSession: (...args) => mockGetSession(...args),
+      onAuthStateChange: (...args) => mockOnAuthStateChange(...args),
+    },
+  },
+  isSupabaseConfigured: true,
+}))
+
+mockGetSession.mockResolvedValue({
+  data: { session: { user: { id: '123' } } },
+})
+
+mockOnAuthStateChange.mockReturnValue({
+  data: { subscription: { unsubscribe: jest.fn() } },
+})
+
+function Consumer() {
+  const { role } = useContext(AuthContext)
+  return <div>{role ?? 'без роли'}</div>
+}
+
+describe('AuthContext', () => {
+  it('логирует ошибку и оставляет роль null при сбое сети', async () => {
+    const errorText = 'Ошибка сети'
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        text: () => Promise.resolve(errorText),
+      }),
+    )
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalled())
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Ошибка получения роли:',
+      expect.objectContaining({ message: errorText }),
+    )
+
+    expect(screen.getByText('без роли')).toBeInTheDocument()
+
+    consoleSpy.mockRestore()
+    globalThis.fetch = originalFetch
+  })
+})


### PR DESCRIPTION
## Описание
- выбрасываем ошибку с текстом ответа при неудачном запросе роли
- логируем и обнуляем роль при ошибке загрузки
- добавлен тест контекста для сбоя сети

## Тестирование
- `npm test -- --config=jest.config.js` *(падает: FAIL tests/useChat.test.jsx, FAIL tests/App.test.jsx)*
- `npx jest --config=jest.config.js tests/AuthContext.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689cd65556088324beea96ead73359ee