### PR TITLE
feat: validate chat file uploads

### DIFF
--- a/src/hooks/useChatMessages.js
+++ b/src/hooks/useChatMessages.js
@@ -1,6 +1,15 @@
 import { supabase } from '../supabaseClient'
 import { v4 as uuidv4 } from 'uuid'
 
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/pdf',
+  'text/plain',
+]
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+
 export function useChatMessages() {
   const fetchMessages = (objectId, { limit, offset } = {}) => {
     let query = supabase
@@ -23,6 +32,12 @@ export function useChatMessages() {
   async function sendMessage({ objectId, sender, content, file }) {
     let fileUrl = null
     if (file) {
+      if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+        return { error: new Error('Unsupported file type') }
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        return { error: new Error('File too large') }
+      }
       const filePath = `${objectId}/${uuidv4()}_${file.name}`
       const { error: uploadError } = await supabase.storage
         .from('chat-files')

--- a/tests/useChatMessages.test.js
+++ b/tests/useChatMessages.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import { useChatMessages } from '../src/hooks/useChatMessages.js'
+
+var mockUpload
+var mockGetPublicUrl
+var mockStorageFrom
+var mockInsert
+var mockSupabaseFrom
+
+jest.mock('../src/supabaseClient.js', () => {
+  mockUpload = jest.fn(() => Promise.resolve({ data: null, error: null }))
+  mockGetPublicUrl = jest.fn(() => ({ data: { publicUrl: 'url' } }))
+  mockStorageFrom = jest.fn(() => ({
+    upload: mockUpload,
+    getPublicUrl: mockGetPublicUrl,
+  }))
+  mockInsert = jest.fn(() => Promise.resolve({ data: null, error: null }))
+  mockSupabaseFrom = jest.fn(() => ({ insert: mockInsert }))
+  return {
+    supabase: {
+      storage: { from: mockStorageFrom },
+      from: mockSupabaseFrom,
+    },
+  }
+})
+
+describe('useChatMessages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('не загружает файлы с неподдерживаемым типом', async () => {
+    const { sendMessage } = useChatMessages()
+    const file = new File(['data'], 'test.bin', {
+      type: 'application/octet-stream',
+    })
+    const { error } = await sendMessage({
+      objectId: '1',
+      sender: 'user@example.com',
+      content: 'msg',
+      file,
+    })
+    expect(error).toBeDefined()
+    expect(mockUpload).not.toHaveBeenCalled()
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it('не загружает файлы, превышающие лимит размера', async () => {
+    const { sendMessage } = useChatMessages()
+    const big = new Uint8Array(6 * 1024 * 1024)
+    const file = new File([big], 'big.png', { type: 'image/png' })
+    const { error } = await sendMessage({
+      objectId: '1',
+      sender: 'user@example.com',
+      content: 'msg',
+      file,
+    })
+    expect(error).toBeDefined()
+    expect(mockUpload).not.toHaveBeenCalled()
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- validate attachments before uploading to Supabase
- test rejection of disallowed files

## Testing
- `npx jest tests/useChatMessages.test.js --config jest.config.js`
- `npm test -- --config jest.config.js` *(fails: Cannot access 'mockSupabase' before initialization in useChat.test.jsx; Unable to find text 'Загрузка...' in App.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6577b308324adf098218541c521