### PR TITLE
fix: корректное имя маппинга модулей для jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,22 +75,5 @@
     "*.{css,scss,md,json}": [
       "prettier --write"
     ]
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": [
-      "<rootDir>/src/setupTests.js"
-    ],
-    "moduleNameMapper": {
-      "\\.(css|less|scss|sass)$": "identity-obj-proxy"
-    },
-    "transform": {
-      "^.+\\.(js|jsx)$": "babel-jest"
-    },
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!src/index.js",
-      "!src/reportWebVitals.js"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,8 +78,10 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"],
-    "moduleNameMapping": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setupTests.js"
+    ],
+    "moduleNameMapper": {
       "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     },
     "transform": {

--- a/src/hooks/useObjects.js
+++ b/src/hooks/useObjects.js
@@ -45,6 +45,6 @@ export function useObjects() {
     fetchObjects,
     insertObject,
     updateObject,
-    deleteObject
+    deleteObject,
   }
 }


### PR DESCRIPTION
## Summary
- fix misnamed Jest module mapping so CSS/SCSS imports use identity-obj-proxy

## Testing
- `npm test -- --config jest.config.js` *(fails: ReferenceError: Cannot access 'mockSupabase' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_689cd65850148324869261ad4add6fed