### PR TITLE
Handle errors when fetching user role

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import { supabase, isSupabaseConfigured } from '../supabaseClient'
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -12,13 +13,20 @@ export function AuthProvider({ children }) {
     if (!isSupabaseConfigured) return
 
     const fetchRole = async (id) => {
-      const res = await fetch(`/functions/v1/cacheGet?table=profiles&id=${id}`)
-      if (!res.ok) {
-        const text = await res.text()
-        throw new Error(text)
+      try {
+        const res = await fetch(
+          `/functions/v1/cacheGet?table=profiles&id=${id}`,
+        )
+        if (!res.ok) {
+          const text = await res.text()
+          throw new Error(text)
+        }
+        const body = await res.json()
+        return { role: body.data?.role ?? null }
+      } catch (error) {
+        toast.error('Ошибка получения роли: ' + error.message)
+        return { error }
       }
-      const body = await res.json()
-      return body.data?.role ?? null
     }
 
     const fetchSession = async () => {
@@ -29,11 +37,13 @@ export function AuthProvider({ children }) {
       setUser(currentUser)
 
       if (currentUser) {
-        try {
-          setRole(await fetchRole(currentUser.id))
-        } catch (error) {
+        const { role: fetchedRole, error } = await fetchRole(currentUser.id)
+        if (error) {
           console.error('Ошибка получения роли:', error)
+          toast.error('Ошибка получения роли: ' + error.message)
           setRole(null)
+        } else {
+          setRole(fetchedRole)
         }
       } else {
         setRole(null)
@@ -48,11 +58,13 @@ export function AuthProvider({ children }) {
       const currentUser = session?.user ?? null
       setUser(currentUser)
       if (currentUser) {
-        try {
-          setRole(await fetchRole(currentUser.id))
-        } catch (error) {
+        const { role: fetchedRole, error } = await fetchRole(currentUser.id)
+        if (error) {
           console.error('Ошибка получения роли:', error)
+          toast.error('Ошибка получения роли: ' + error.message)
           setRole(null)
+        } else {
+          setRole(fetchedRole)
         }
       } else {
         setRole(null)

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -1,4 +1,12 @@
 // Move mocks before imports to avoid initialization errors
+let mockSupabase
+
+jest.mock('../src/supabaseClient.js', () => ({
+  get supabase() {
+    return mockSupabase
+  },
+}))
+
 const mockError = new Error('update failed')
 
 // Mock Supabase client first
@@ -10,7 +18,7 @@ const updateChain = {
   })),
 }
 
-const mockSupabase = {
+mockSupabase = {
   from: jest.fn(() => ({ update: jest.fn(() => updateChain) })),
   channel: jest.fn(() => ({
     on: jest.fn().mockReturnThis(),
@@ -18,10 +26,6 @@ const mockSupabase = {
   })),
   removeChannel: jest.fn(),
 }
-
-jest.mock('../src/supabaseClient.js', () => ({
-  supabase: mockSupabase,
-}))
 
 jest.mock('../src/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
@@ -58,6 +62,7 @@ const mockFetchMessages = jest
   .fn()
   .mockResolvedValueOnce({ data: page1, error: null })
   .mockResolvedValueOnce({ data: page2, error: null })
+  .mockResolvedValue({ data: [], error: null })
 const mockSendMessage = jest.fn()
 
 // Mock the useChatMessages hook


### PR DESCRIPTION
## Summary
- wrap role fetch in try/catch and show toast on error
- propagate errors to callers and notify users
- stabilize useChat tests by mocking Supabase lazily

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce40215848324bfea26b31a4b6666