### PR TITLE
feat: add assignee_id migration and index

### DIFF
--- a/supabase/migrations/20250814000000_add-indexes.sql
+++ b/supabase/migrations/20250814000000_add-indexes.sql
@@ -1,5 +1,6 @@
 create index tasks_object_id_idx on tasks(object_id);
 create index tasks_assignee_idx on tasks(assignee);
+create index tasks_assignee_id_idx on tasks(assignee_id);
 create index tasks_created_at_idx on tasks(created_at);
 create index hardware_object_id_idx on hardware(object_id);
 create index hardware_created_at_idx on hardware(created_at);

--- a/supabase/migrations/20250815000000_add-assignee-id-column.sql
+++ b/supabase/migrations/20250815000000_add-assignee-id-column.sql
@@ -1,0 +1,16 @@
+alter table tasks
+  add column if not exists assignee_id uuid;
+
+-- migrate existing values from executor_id to assignee_id if the old column exists
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_name = 'tasks' and column_name = 'executor_id'
+  ) then
+    update tasks set assignee_id = executor_id where assignee_id is null;
+  end if;
+end $$;
+
+-- drop legacy column
+alter table tasks drop column if exists executor_id;


### PR DESCRIPTION
## Summary
- add migration that introduces `assignee_id` and migrates values from `executor_id`
- index `assignee_id` for faster task lookups

## Testing
- `npm test`
- `npx supabase migration up` *(fails: connect ECONNREFUSED 127.0.0.1:54322)*
- `npx supabase start` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d650a1308324b6c641f992beac88