### PR TITLE
Validate component props and add TypeScript example

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ export default {
         presets: [
           ['@babel/preset-env', { targets: { node: 'current' } }],
           ['@babel/preset-react', { runtime: 'automatic' }],
+          '@babel/preset-typescript',
         ],
         plugins: ['babel-plugin-transform-vite-meta-env'],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,13 @@
       "devDependencies": {
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.32.0",
         "@redocly/cli": "^2.0.5",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.1.2",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "@vheemstra/vite-plugin-imagemin": "^2.2.0",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/ui": "^1.6.0",
@@ -52,6 +55,7 @@
         "prettier": "^3.4.2",
         "start-server-and-test": "^2.0.4",
         "tailwindcss": "^3.4.1",
+        "typescript": "^5.4.2",
         "vite": "^4.0.0",
         "vite-plugin-compression": "^0.5.1",
         "vitest": "^1.6.0",
@@ -1736,6 +1740,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1916,6 +1940,26 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6092,8 +6136,7 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
@@ -6101,7 +6144,6 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -21020,6 +21062,20 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,13 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.32.0",
     "@redocly/cli": "^2.0.5",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.1.2",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@vheemstra/vite-plugin-imagemin": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "@vitest/ui": "^1.6.0",
@@ -67,6 +70,7 @@
     "vite": "^4.0.0",
     "vite-plugin-compression": "^0.5.1",
     "vitest": "^1.6.0",
+    "typescript": "^5.4.2",
     "webpagetest": "^0.7.6"
   },
   "lint-staged": {

--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import { useAccount } from '../hooks/useAccount'
 import { toast } from 'react-hot-toast'
 
@@ -54,4 +55,10 @@ export default function AccountModal({ user, onClose, onUpdated }) {
       </div>
     </div>
   )
+}
+
+AccountModal.propTypes = {
+  user: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onUpdated: PropTypes.func.isRequired,
 }

--- a/src/components/AdminRoute.jsx
+++ b/src/components/AdminRoute.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 export default function AdminRoute({ children }) {
   const { isAdmin } = useAuth()
   return isAdmin ? children : <Navigate to="/auth" replace />
+}
+
+AdminRoute.propTypes = {
+  children: PropTypes.node.isRequired,
 }

--- a/src/components/AttachmentPreview.jsx
+++ b/src/components/AttachmentPreview.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 
 export default function AttachmentPreview({ url, onImageClick }) {
   const [open, setOpen] = useState(false)
@@ -109,4 +110,13 @@ export default function AttachmentPreview({ url, onImageClick }) {
       </div>
     </>
   )
+}
+
+AttachmentPreview.propTypes = {
+  url: PropTypes.string.isRequired,
+  onImageClick: PropTypes.func,
+}
+
+AttachmentPreview.defaultProps = {
+  onImageClick: null,
 }

--- a/src/components/AuditTrail.jsx
+++ b/src/components/AuditTrail.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { supabase } from '../supabaseClient'
 import Spinner from './Spinner'
 import ErrorMessage from './ErrorMessage'
 
-export default function AuditTrail({ limit = 50 }) {
+export default function AuditTrail({ limit }) {
   const [logs, setLogs] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -69,4 +70,12 @@ export default function AuditTrail({ limit = 50 }) {
       </table>
     </div>
   )
+}
+
+AuditTrail.propTypes = {
+  limit: PropTypes.number,
+}
+
+AuditTrail.defaultProps = {
+  limit: 50,
 }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-export default function Card({ children, className = '', ...props }) {
+export default function Card({ children, className, ...props }) {
   return (
     <div
       className={`rounded-2xl shadow-md p-4 bg-base-100 transition-colors ${className}`}
@@ -9,4 +10,13 @@ export default function Card({ children, className = '', ...props }) {
       {children}
     </div>
   )
+}
+
+Card.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+}
+
+Card.defaultProps = {
+  className: '',
 }

--- a/src/components/ChatCard.jsx
+++ b/src/components/ChatCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Card from './Card'
 import { linkifyText } from '../utils/linkify.jsx'
 
@@ -35,4 +36,8 @@ export default function ChatCard({ message }) {
       )}
     </Card>
   )
+}
+
+ChatCard.propTypes = {
+  message: PropTypes.object.isRequired,
 }

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -1,4 +1,5 @@
 import { memo, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { PaperClipIcon } from '@heroicons/react/24/outline'
@@ -147,3 +148,12 @@ function ChatTab({ selected, userEmail }) {
 }
 
 export default memo(ChatTab)
+
+ChatTab.propTypes = {
+  selected: PropTypes.object,
+  userEmail: PropTypes.string.isRequired,
+}
+
+ChatTab.defaultProps = {
+  selected: null,
+}

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 export default function ConfirmModal({
   open,
   title,
   message,
-  confirmLabel = 'OK',
-  cancelLabel = 'Отмена',
-  confirmClass = 'btn-error',
+  confirmLabel,
+  cancelLabel,
+  confirmClass,
   onConfirm,
   onCancel,
 }) {
@@ -27,4 +28,23 @@ export default function ConfirmModal({
       </div>
     </div>
   )
+}
+
+ConfirmModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string,
+  message: PropTypes.string,
+  confirmLabel: PropTypes.node,
+  cancelLabel: PropTypes.node,
+  confirmClass: PropTypes.string,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+}
+
+ConfirmModal.defaultProps = {
+  title: '',
+  message: '',
+  confirmLabel: 'OK',
+  cancelLabel: 'Отмена',
+  confirmClass: 'btn-error',
 }

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,11 +1,22 @@
+import React from 'react'
+
+interface ErrorMessageProps {
+  error?: { message?: string }
+  message?: string
+}
+
 export default function ErrorMessage({
   error,
   message = 'Ошибка загрузки данных',
-}) {
+}: ErrorMessageProps) {
   const text = error?.message ? `${message}: ${error.message}` : message
   return (
     <div className="text-center text-red-500 p-4" role="alert">
       {text}
     </div>
   )
+}
+
+ErrorMessage.defaultProps = {
+  message: 'Ошибка загрузки данных',
 }

--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -1,9 +1,10 @@
 // src/components/HardwareCard.jsx
 import React from 'react'
+import PropTypes from 'prop-types'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
-export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
+export default function HardwareCard({ item, onEdit, onDelete, user }) {
   return (
     <Card className="flex justify-between items-center">
       <div>
@@ -36,4 +37,15 @@ export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
       )}
     </Card>
   )
+}
+
+HardwareCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  user: PropTypes.object,
+}
+
+HardwareCard.defaultProps = {
+  user: null,
 }

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react'
+import PropTypes from 'prop-types'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
@@ -8,7 +9,7 @@ function InventorySidebar({
   onSelect,
   onEdit,
   onDelete,
-  notifications = {},
+  notifications,
 }) {
   const items = useMemo(
     () =>
@@ -65,3 +66,17 @@ function InventorySidebar({
 }
 
 export default memo(InventorySidebar)
+
+InventorySidebar.propTypes = {
+  objects: PropTypes.arrayOf(PropTypes.object).isRequired,
+  selected: PropTypes.object,
+  onSelect: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  notifications: PropTypes.object,
+}
+
+InventorySidebar.defaultProps = {
+  selected: null,
+  notifications: {},
+}

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
+import PropTypes from 'prop-types'
 
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -40,7 +41,7 @@ function formatDate(dateStr) {
   }
 }
 
-function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
+function InventoryTabs({ selected, onUpdateSelected, onTabChange }) {
   const navigate = useNavigate()
   const { user } = useAuth()
   // --- вкладки и описание ---
@@ -1133,3 +1134,13 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
 }
 
 export default React.memo(InventoryTabs)
+
+InventoryTabs.propTypes = {
+  selected: PropTypes.object.isRequired,
+  onUpdateSelected: PropTypes.func.isRequired,
+  onTabChange: PropTypes.func,
+}
+
+InventoryTabs.defaultProps = {
+  onTabChange: () => {},
+}

--- a/src/components/ObjectCard.jsx
+++ b/src/components/ObjectCard.jsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import PropTypes from 'prop-types'
 import Card from './Card'
 
 function ObjectCard({ item }) {
@@ -13,3 +14,7 @@ function ObjectCard({ item }) {
 }
 
 export default memo(ObjectCard)
+
+ObjectCard.propTypes = {
+  item: PropTypes.object.isRequired,
+}

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 export default function PrivateRoute({ children }) {
   const { user } = useAuth()
   return user ? children : <Navigate to="/auth" replace />
+}
+
+PrivateRoute.propTypes = {
+  children: PropTypes.node.isRequired,
 }

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useCallback } from 'react'
+import PropTypes from 'prop-types'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
@@ -95,3 +96,10 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
 }
 
 export default memo(TaskCard)
+
+TaskCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onView: PropTypes.func.isRequired,
+}

--- a/src/components/WhatsAppIcon.jsx
+++ b/src/components/WhatsAppIcon.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-export default function WhatsAppIcon({ className = 'w-5 h-5' }) {
+export default function WhatsAppIcon({ className }) {
   return (
     <svg
       viewBox="0 0 24 24"
@@ -21,4 +22,12 @@ export default function WhatsAppIcon({ className = 'w-5 h-5' }) {
       />
     </svg>
   )
+}
+
+WhatsAppIcon.propTypes = {
+  className: PropTypes.string,
+}
+
+WhatsAppIcon.defaultProps = {
+  className: 'w-5 h-5',
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add PropTypes and defaultProps across React components
- migrate ErrorMessage component to TypeScript and add tsconfig
- configure Jest and package.json for TypeScript support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d98514a88324b0168b8c3ab155f7