### PR TITLE
feat: handle missing API base URL in env notice

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,0 +1,5 @@
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+export const isApiConfigured = Boolean(apiBaseUrl)
+
+export { apiBaseUrl }

--- a/src/pages/MissingEnvPage.jsx
+++ b/src/pages/MissingEnvPage.jsx
@@ -1,14 +1,33 @@
 import React from 'react'
+import { isApiConfigured } from '../apiConfig'
+import { isSupabaseConfigured } from '../supabaseClient'
 
 export default function MissingEnvPage() {
+  const missingVars = []
+  const targets = []
+
+  if (!isSupabaseConfigured) {
+    missingVars.push('VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY')
+    targets.push('базе данных')
+  }
+
+  if (!isApiConfigured) {
+    missingVars.push('VITE_API_BASE_URL')
+    targets.push('API')
+  }
+
+  const varsText = missingVars.join(', ')
+  const prefix =
+    missingVars.length > 1 ? 'Переменные окружения' : 'Переменная окружения'
+  const targetsText = targets.join(' и ')
+
   return (
     <div className="flex h-screen items-center justify-center bg-base-200 transition-colors">
       <div className="flex w-full min-h-screen items-center justify-center bg-base-200">
         <div className="alert alert-error max-w-md text-center shadow-lg">
           <span>
-            Переменные окружения VITE_SUPABASE_URL и VITE_SUPABASE_ANON_KEY не
-            заданы. Приложение не может подключиться к базе данных и работает в
-            ограниченном режиме.
+            {prefix} {varsText} не заданы. Приложение не может подключиться к{' '}
+            {targetsText} и работает в ограниченном режиме.
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- check API base URL alongside Supabase vars in missing env page
- add apiConfig helper for API base URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0df638e7c8324a1d55bba78cb7596