### PR TITLE
feat: предупреждение при отсутствии API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
-import React, { Suspense, lazy } from 'react'
+import React, { Suspense, lazy, useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import { Toaster } from 'react-hot-toast'
+import { Toaster, toast } from 'react-hot-toast'
 import { isSupabaseConfigured } from './supabaseClient'
 import { isApiConfigured } from './apiConfig'
 import PrivateRoute from './components/PrivateRoute'
@@ -10,7 +10,15 @@ const DashboardPage = lazy(() => import('./pages/DashboardPage'))
 const MissingEnvPage = lazy(() => import('./pages/MissingEnvPage'))
 
 export default function App() {
-  if (!isSupabaseConfigured || !isApiConfigured) {
+  useEffect(() => {
+    if (isSupabaseConfigured && !isApiConfigured) {
+      toast('API не настроен. Некоторые функции будут недоступны.', {
+        icon: '⚠️',
+      })
+    }
+  }, [])
+
+  if (!isSupabaseConfigured) {
     return (
       <Suspense fallback={<div>Loading...</div>}>
         <MissingEnvPage />

--- a/src/pages/MissingEnvPage.jsx
+++ b/src/pages/MissingEnvPage.jsx
@@ -24,11 +24,21 @@ export default function MissingEnvPage() {
   return (
     <div className="flex h-screen items-center justify-center bg-base-200 transition-colors">
       <div className="flex w-full min-h-screen items-center justify-center bg-base-200">
-        <div className="alert alert-error max-w-md text-center shadow-lg">
-          <span>
-            {prefix} {varsText} не заданы. Приложение не может подключиться к{' '}
-            {targetsText} и работает в ограниченном режиме.
-          </span>
+        <div className="space-y-4 max-w-md text-center">
+          <div className="alert alert-error shadow-lg">
+            <span>
+              {prefix} {varsText} не заданы. Приложение не может подключиться к{' '}
+              {targetsText} и работает в ограниченном режиме.
+            </span>
+          </div>
+          {!isApiConfigured && (
+            <div className="alert alert-warning shadow-lg">
+              <span>
+                Без API недоступны управление объектами, импорт и экспорт
+                данных, а также получение ролей пользователей.
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- показывать предупреждение о не настроенном API вместо блокировки интерфейса
- дополнить MissingEnvPage описанием функций, недоступных без API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e801c9008324a3fa3d198913874c