### PR TITLE
refactor: unify network error handling in AuthPage

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -40,18 +40,24 @@ export default function AuthPage() {
     formState: { errors },
   } = useForm({ resolver: zodResolver(schema) })
 
+  function getNetworkErrorMessage(error) {
+    if (
+      error instanceof TypeError ||
+      (error.message && error.message.toLowerCase().includes('failed to fetch'))
+    ) {
+      console.error(error)
+      return 'Не удалось подключиться к серверу. Попробуйте позже.'
+    }
+    return error.message
+  }
+
   async function onSubmit({ email, password, username }) {
     setUserError(null)
     setInfo(null)
     if (isRegister) {
       const { data, error } = await signUp(email, password, username)
       if (error) {
-        if (error.name === 'FetchError') {
-          console.error(error)
-          setUserError('Не удалось подключиться к серверу. Попробуйте позже.')
-        } else {
-          setUserError(error.message)
-        }
+        setUserError(getNetworkErrorMessage(error))
       } else if (data.user && data.user.confirmed_at === null) {
         setInfo('Проверьте почту для подтверждения аккаунта')
       } else if (!data.session) {
@@ -64,12 +70,7 @@ export default function AuthPage() {
     } else {
       const { data, error } = await signIn(email, password)
       if (error) {
-        if (error.name === 'FetchError') {
-          console.error(error)
-          setUserError('Не удалось подключиться к серверу. Попробуйте позже.')
-        } else {
-          setUserError(error.message)
-        }
+        setUserError(getNetworkErrorMessage(error))
       } else if (!data.session) {
         setInfo(
           'Нет активной сессии. Подтвердите аккаунт или проверьте конфигурацию.',


### PR DESCRIPTION
## Summary
- replace FetchError name comparison with TypeError-based network error detection in AuthPage
- centralize user-facing network error message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb9dacec8324a51fd79348b3ef42