### PR TITLE
refactor: handle session with try catch

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -82,21 +82,35 @@ export default function AuthPage() {
 
   useEffect(() => {
     let isMounted = true
-    getSession().then(({ data: { session } }) => {
-      if (session && isMounted) {
-        navigate('/')
+    let subscription
+
+    const checkSession = async () => {
+      try {
+        const {
+          data: { session },
+        } = await getSession()
+        if (session && isMounted) {
+          navigate('/')
+        }
+        ;({
+          data: { subscription },
+        } = onAuthStateChange((_event, session) => {
+          if (session) {
+            navigate('/')
+          }
+        }))
+      } catch (error) {
+        console.error(error)
+        setUserError('Не удалось получить сессию. Попробуйте позже.')
+        return
       }
-    })
-    const {
-      data: { subscription },
-    } = onAuthStateChange((_event, session) => {
-      if (session) {
-        navigate('/')
-      }
-    })
+    }
+
+    checkSession()
+
     return () => {
       isMounted = false
-      subscription.unsubscribe()
+      subscription?.unsubscribe()
     }
   }, [navigate])
 


### PR DESCRIPTION
## Summary
- refactor session check in AuthPage to use async try/catch and show error to user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb9d7d108324a60e5bd2af6e211d