### PR TITLE
Add environment example and MissingEnvPage test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Обязательные переменные окружения
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+VITE_API_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Inventory App — приложение на React, которое помогае
 1. Зарегистрируйтесь на [Supabase](https://supabase.com) и создайте проект.
 2. В настройках проекта откройте `Settings → API`.
 3. Скопируйте `URL` проекта и `anon`-ключ.
-4. Скопируйте файл `.env.example` в `.env` и заполните `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` и `VITE_API_BASE_URL`.
+4. Скопируйте файл `.env.example` в `.env` (например, `cp .env.example .env`) и заполните `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` и `VITE_API_BASE_URL`.
    Если `VITE_API_BASE_URL` не указана, запросы к API завершатся ошибкой и интерфейс не сможет загрузить данные.
    Пример: `VITE_API_BASE_URL=https://<project-ref>.supabase.co` — значение берётся в Supabase в разделе `Settings → API` в поле `Project URL`.
 5. Установите зависимости: `npm install`.

--- a/tests/MissingEnvPage.test.jsx
+++ b/tests/MissingEnvPage.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@/supabaseClient.js', () => ({
+  isSupabaseConfigured: false,
+}))
+jest.mock('@/apiConfig.js', () => ({
+  isApiConfigured: false,
+}))
+
+import App from '@/App'
+
+describe('MissingEnvPage', () => {
+  it('отображает предупреждение при отсутствии переменных окружения', async () => {
+    render(<App />)
+    expect(
+      await screen.findByText(
+        /VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_API_BASE_URL не заданы/i,
+      ),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- provide `.env.example` with required variables
- document copying env template in README
- test MissingEnvPage renders when env vars are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18ec2adc483248091cb902968279f