### PR TITLE
Удалён defaultProps в ErrorMessage

### DIFF
--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -16,7 +16,3 @@ export default function ErrorMessage({
     </div>
   )
 }
-
-ErrorMessage.defaultProps = {
-  message: 'Ошибка загрузки данных',
-}


### PR DESCRIPTION
## Summary
- remove legacy defaultProps from ErrorMessage and rely on parameter default

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18ec5f4988324b470943907ea85ea