### PR TITLE
Добавлен ErrorBoundary и тест на перехват ошибок

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy, useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import ErrorBoundary from './components/ErrorBoundary'
 import { Toaster, toast } from 'react-hot-toast'
 import { isSupabaseConfigured } from './supabaseClient'
 import { isApiConfigured } from './apiConfig'
@@ -30,17 +31,19 @@ export default function App() {
     <BrowserRouter>
       <Suspense fallback={<div>Loading...</div>}>
         <Toaster position="top-right" />
-        <Routes>
-          <Route path="/auth" element={<AuthPage />} />
-          <Route
-            path="/*"
-            element={
-              <PrivateRoute>
-                <DashboardPage />
-              </PrivateRoute>
-            }
-          />
-        </Routes>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/auth" element={<AuthPage />} />
+            <Route
+              path="/*"
+              element={
+                <PrivateRoute>
+                  <DashboardPage />
+                </PrivateRoute>
+              }
+            />
+          </Routes>
+        </ErrorBoundary>
       </Suspense>
     </BrowserRouter>
   )

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Произошла ошибка.</div>
+    }
+    return this.props.children
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default ErrorBoundary

--- a/tests/ErrorBoundary.test.jsx
+++ b/tests/ErrorBoundary.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ErrorBoundary from '@/components/ErrorBoundary'
+
+function ProblemComponent() {
+  throw new Error('Test error')
+}
+
+describe('ErrorBoundary', () => {
+  it('перехватывает ошибки и отображает резервный UI', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <ErrorBoundary>
+        <ProblemComponent />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Произошла ошибка.')).toBeInTheDocument()
+    expect(spy).toHaveBeenCalled()
+
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- внедрён компонент ErrorBoundary с выводом резервного UI при ошибках
- <Routes> обёрнут в ErrorBoundary
- добавлен тест, проверяющий перехват ошибок

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18ec33eb88324900e3a22e4ec5458