### PR TITLE
fix: load chat messages once on subscribe

### DIFF
--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -90,7 +90,9 @@ export default function useChat({ objectId, userEmail }) {
     offsetRef.current = 0
     if (!objectId) return
 
-    loadMore()
+    // loadMore() вызывает двойную загрузку при инициализации,
+    // поэтому оставляем вызов только после подписки на канал
+    // loadMore()
 
     const ch = supabase
       .channel(`chat:${objectId}`)

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -40,7 +40,10 @@ jest.mock('../src/supabaseClient.js', () => {
   }))
   const mockChannel = jest.fn(() => ({
     on: jest.fn().mockReturnThis(),
-    subscribe: jest.fn(),
+    subscribe: jest.fn((cb) => {
+      cb('SUBSCRIBED')
+      return { unsubscribe: jest.fn() }
+    }),
   }))
   const mockRemoveChannel = jest.fn()
   return {

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -22,7 +22,10 @@ mockSupabase = {
   from: jest.fn(() => ({ update: jest.fn(() => updateChain) })),
   channel: jest.fn(() => ({
     on: jest.fn().mockReturnThis(),
-    subscribe: jest.fn(),
+    subscribe: jest.fn((cb) => {
+      cb('SUBSCRIBED')
+      return { unsubscribe: jest.fn() }
+    }),
   })),
   removeChannel: jest.fn(),
 }


### PR DESCRIPTION
## Summary
- avoid duplicate initial load in chat hook
- update tests to simulate subscribed channel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb2586b08324ac07ffddd58ffc40