### PR TITLE
feat: handle missing assignee column

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -7,13 +7,29 @@ export function useTasks() {
 
   const fetchTasks = async (objectId) => {
     try {
-      const result = await supabase
+      const baseFields =
+        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+      const fallbackFields =
+        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+      let result = await supabase
         .from('tasks')
-        .select(
-          'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes',
-        )
+        .select(baseFields)
         .eq('object_id', objectId)
         .order('created_at')
+      if (result.error?.code === '42703') {
+        result = await supabase
+          .from('tasks')
+          .select(fallbackFields)
+          .eq('object_id', objectId)
+          .order('created_at')
+        if (!result.error && result.data) {
+          result.data = result.data.map((task) => ({
+            ...task,
+            assignee_id: null,
+            executor_id: null,
+          }))
+        }
+      }
       if (result.error) throw result.error
       return result
     } catch (error) {
@@ -24,13 +40,25 @@ export function useTasks() {
 
   const insertTask = async (data) => {
     try {
-      const result = await supabase
+      const baseFields =
+        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+      const fallbackFields =
+        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+      let result = await supabase
         .from('tasks')
         .insert([data])
-        .select(
-          'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes',
-        )
+        .select(baseFields)
         .single()
+      if (result.error?.code === '42703') {
+        result = await supabase
+          .from('tasks')
+          .insert([data])
+          .select(fallbackFields)
+          .single()
+        if (!result.error && result.data) {
+          result.data = { ...result.data, assignee_id: null, executor_id: null }
+        }
+      }
       if (result.error) throw result.error
       return result
     } catch (error) {
@@ -41,14 +69,27 @@ export function useTasks() {
 
   const updateTask = async (id, data) => {
     try {
-      const result = await supabase
+      const baseFields =
+        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+      const fallbackFields =
+        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+      let result = await supabase
         .from('tasks')
         .update(data)
         .eq('id', id)
-        .select(
-          'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes',
-        )
+        .select(baseFields)
         .single()
+      if (result.error?.code === '42703') {
+        result = await supabase
+          .from('tasks')
+          .update(data)
+          .eq('id', id)
+          .select(fallbackFields)
+          .single()
+        if (!result.error && result.data) {
+          result.data = { ...result.data, assignee_id: null, executor_id: null }
+        }
+      }
       if (result.error) throw result.error
       return result
     } catch (error) {

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -15,12 +15,20 @@ var mockSingle
 var mockSelect
 var mockInsert
 var mockFrom
+var mockEq
+var mockOrder
 
 jest.mock('../src/supabaseClient.js', () => {
   mockSingle = jest.fn(() => Promise.resolve({ data: null, error: null }))
-  mockSelect = jest.fn(() => ({ single: mockSingle }))
+  mockOrder = jest.fn(() => Promise.resolve({ data: null, error: null }))
+  mockEq = jest.fn(() => ({ order: mockOrder }))
+  mockSelect = jest.fn(() => ({
+    single: mockSingle,
+    eq: mockEq,
+    order: mockOrder,
+  }))
   mockInsert = jest.fn(() => ({ select: mockSelect }))
-  mockFrom = jest.fn(() => ({ insert: mockInsert }))
+  mockFrom = jest.fn(() => ({ insert: mockInsert, select: mockSelect }))
   return { supabase: { from: mockFrom } }
 })
 
@@ -40,5 +48,37 @@ describe('useTasks', () => {
       expect.any(Function),
       'Ошибка добавления задачи',
     )
+  })
+
+  it('повторно запрашивает задачи при отсутствии assignee_id', async () => {
+    mockOrder
+      .mockResolvedValueOnce({ data: null, error: { code: '42703' } })
+      .mockResolvedValueOnce({
+        data: [{ id: 1, title: 't', assignee: 'a', executor: 'e' }],
+        error: null,
+      })
+
+    const { result } = renderHook(() => useTasks())
+    const { data, error } = await result.current.fetchTasks(1)
+    expect(error).toBeNull()
+    expect(data).toEqual([
+      {
+        id: 1,
+        title: 't',
+        assignee: 'a',
+        executor: 'e',
+        assignee_id: null,
+        executor_id: null,
+      },
+    ])
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('assignee_id'),
+    )
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      2,
+      expect.not.stringContaining('assignee_id'),
+    )
+    expect(mockHandleSupabaseError).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- handle 42703 undefined column for assignee_id
- requery existing columns and normalize result when assignee_id missing
- test fallback querying when assignee_id column absent

## Testing
- `npm test` *(fails: useChat.test.jsx, ChatTab.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eccefa2c8324af4fa241a6bcd7fb