### PR TITLE
fix: prevent duplicate role fetch error toast

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -31,7 +31,7 @@ export function AuthProvider({ children }) {
         const body = await res.json()
         return { role: body.data?.role ?? null }
       } catch (error) {
-        toast.error('Ошибка получения роли: ' + error.message)
+        // toast.error('Ошибка получения роли: ' + error.message)
         return { error }
       }
     }


### PR DESCRIPTION
## Summary
- avoid duplicate role fetch error toasts by removing internal toast call

## Testing
- `npm test` *(fails: tests/useChat.test.jsx, others passed)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a2efe7a7b08324b80495e123ead4b1