### PR TITLE
Restrict cacheGet to authorized profiles access

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@
 - `supabase/functions/import` — Edge Function, принимающая CSV/XLSX и импортирующая данные.
 - `supabase/functions/export` — Edge Function, формирующая выгрузку таблиц.
 - `supabase/functions/import-export` — комбинированные функции для пакетной обработки данных.
+- `supabase/functions/cacheGet` — Edge Function для чтения данных с кэшированием.
 - `supabase/migrations` — SQL-скрипты для создания и изменения структуры БД.
 - `tests` — модульные тесты Vitest.
 
@@ -38,3 +39,7 @@ sequenceDiagram
     F->>D: Дополнительная обработка
     D-->>C: Ответ
 ```
+
+## Ограничения функции cacheGet
+
+Edge Function `cacheGet` обслуживает только таблицы из разрешённого списка (на текущий момент `profiles`). Для обращения к функции требуется заголовок `Authorization` с действительным токеном. Запросы к запрещённым таблицам возвращают ответ `403`, отсутствие или неверный токен приводит к ответу `401`.


### PR DESCRIPTION
## Summary
- allow cacheGet to work only with the `profiles` table
- enforce Authorization header and token validation for cacheGet requests
- document cacheGet limitations

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a2f87787408324ac738b36be5bdd33