### PR TITLE
refactor: inline default props in component signatures

### DIFF
--- a/src/components/AttachmentPreview.jsx
+++ b/src/components/AttachmentPreview.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
-export default function AttachmentPreview({ url, onImageClick }) {
+export default function AttachmentPreview({ url, onImageClick = null }) {
   const [open, setOpen] = useState(false)
 
   const cleanUrl = url?.split('?')[0].split('#')[0] || ''
@@ -115,8 +115,4 @@ export default function AttachmentPreview({ url, onImageClick }) {
 AttachmentPreview.propTypes = {
   url: PropTypes.string.isRequired,
   onImageClick: PropTypes.func,
-}
-
-AttachmentPreview.defaultProps = {
-  onImageClick: null,
 }

--- a/src/components/AuditTrail.jsx
+++ b/src/components/AuditTrail.jsx
@@ -4,7 +4,7 @@ import { supabase } from '../supabaseClient'
 import Spinner from './Spinner'
 import ErrorMessage from './ErrorMessage'
 
-export default function AuditTrail({ limit }) {
+export default function AuditTrail({ limit = 50 }) {
   const [logs, setLogs] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -74,8 +74,4 @@ export default function AuditTrail({ limit }) {
 
 AuditTrail.propTypes = {
   limit: PropTypes.number,
-}
-
-AuditTrail.defaultProps = {
-  limit: 50,
 }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default function Card({ children, className, ...props }) {
+export default function Card({ children, className = '', ...props }) {
   return (
     <div
       className={`rounded-2xl shadow-md p-4 bg-base-100 transition-colors ${className}`}
@@ -15,8 +15,4 @@ export default function Card({ children, className, ...props }) {
 Card.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-}
-
-Card.defaultProps = {
-  className: '',
 }

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -5,7 +5,7 @@ import AttachmentPreview from './AttachmentPreview.jsx'
 import { PaperClipIcon } from '@heroicons/react/24/outline'
 import useChat from '../hooks/useChat.js'
 
-function ChatTab({ selected, userEmail }) {
+function ChatTab({ selected = null, userEmail }) {
   const objectId = selected?.id || null
   const {
     messages,
@@ -152,8 +152,4 @@ export default memo(ChatTab)
 ChatTab.propTypes = {
   selected: PropTypes.object,
   userEmail: PropTypes.string.isRequired,
-}
-
-ChatTab.defaultProps = {
-  selected: null,
 }

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 
 export default function ConfirmModal({
   open,
-  title,
-  message,
-  confirmLabel,
-  cancelLabel,
-  confirmClass,
+  title = '',
+  message = '',
+  confirmLabel = 'OK',
+  cancelLabel = 'Отмена',
+  confirmClass = 'btn-error',
   onConfirm,
   onCancel,
 }) {
@@ -39,12 +39,4 @@ ConfirmModal.propTypes = {
   confirmClass: PropTypes.string,
   onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-}
-
-ConfirmModal.defaultProps = {
-  title: '',
-  message: '',
-  confirmLabel: 'OK',
-  cancelLabel: 'Отмена',
-  confirmClass: 'btn-error',
 }

--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
-export default function HardwareCard({ item, onEdit, onDelete, user }) {
+export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
   return (
     <Card className="flex justify-between items-center">
       <div>
@@ -44,8 +44,4 @@ HardwareCard.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   user: PropTypes.object,
-}
-
-HardwareCard.defaultProps = {
-  user: null,
 }

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -5,11 +5,11 @@ import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
 function InventorySidebar({
   objects,
-  selected,
+  selected = null,
   onSelect,
   onEdit,
   onDelete,
-  notifications,
+  notifications = {},
 }) {
   const items = useMemo(
     () =>
@@ -74,9 +74,4 @@ InventorySidebar.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   notifications: PropTypes.object,
-}
-
-InventorySidebar.defaultProps = {
-  selected: null,
-  notifications: {},
 }

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -40,7 +40,7 @@ function formatDate(dateStr) {
   }
 }
 
-function InventoryTabs({ selected, onUpdateSelected, onTabChange }) {
+function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
   const navigate = useNavigate()
   const { user } = useAuth()
   // --- вкладки и описание ---
@@ -1146,8 +1146,4 @@ InventoryTabs.propTypes = {
   selected: PropTypes.object.isRequired,
   onUpdateSelected: PropTypes.func.isRequired,
   onTabChange: PropTypes.func,
-}
-
-InventoryTabs.defaultProps = {
-  onTabChange: () => {},
 }

--- a/src/components/WhatsAppIcon.jsx
+++ b/src/components/WhatsAppIcon.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default function WhatsAppIcon({ className }) {
+export default function WhatsAppIcon({ className = 'w-5 h-5' }) {
   return (
     <svg
       viewBox="0 0 24 24"
@@ -26,8 +26,4 @@ export default function WhatsAppIcon({ className }) {
 
 WhatsAppIcon.propTypes = {
   className: PropTypes.string,
-}
-
-WhatsAppIcon.defaultProps = {
-  className: 'w-5 h-5',
 }


### PR DESCRIPTION
## Summary
- inline default props directly in component signatures across components
- drop redundant `Component.defaultProps` blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2f8a70d14832495d8c53ff1a035cc