### PR TITLE
Нормализация сравнения адресов отправителя в чате

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -60,7 +60,9 @@ function ChatTab({ selected, userEmail }) {
           </div>
         ) : (
           messages.map((m) => {
-            const isOwn = m.sender === userEmail
+            const isOwn =
+              (m.sender || '').trim().toLowerCase() ===
+              (userEmail || '').trim().toLowerCase()
             const dt = new Date(m.created_at)
             const date = dt.toLocaleDateString()
             const time = dt.toLocaleTimeString([], {


### PR DESCRIPTION
## Summary
- Сравнение e-mail отправителя и текущего пользователя выполняется без учёта регистра и лишних пробелов
- Сообщения текущего пользователя получают класс `chat-end`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2f8befe6483249077ca538a4b1ea6