### PR TITLE
Исправлено получение роли при отсутствии профиля

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -44,7 +44,7 @@ export function AuthProvider({ children }) {
                 .from('profiles')
                 .select('role')
                 .eq('id', id)
-                .single()
+                .maybeSingle()
               if (fallbackError) throw fallbackError
               return { role: data?.role ?? null }
             } catch (error) {

--- a/supabase/functions/cacheGet/index.ts
+++ b/supabase/functions/cacheGet/index.ts
@@ -69,7 +69,7 @@ serve(async (req) => {
 
   let query
   if (id) {
-    query = supabase.from(table).select('*').eq('id', id).single()
+    query = supabase.from(table).select('*').eq('id', id).maybeSingle()
   } else {
     query = supabase.from(table).select('*')
   }


### PR DESCRIPTION
## Summary
- avoid error when profile is missing by using `maybeSingle`
- handle role fetch gracefully without profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2fcd157b48324bf6e66ab979ae015