### PR TITLE
Показывать последние сообщения чата после загрузки

### DIFF
--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -33,7 +33,7 @@ export default function useChat({ objectId, userEmail }) {
       return
     }
     offsetRef.current += data?.length || 0
-    setMessages((prev) => [...(data || []), ...prev].sort(sortByCreatedAt))
+    setMessages((prev) => [...(data || []), ...prev])
     if (!data || data.length < LIMIT) setHasMore(false)
   }, [objectId, fetchMessages])
 

--- a/src/hooks/useChatMessages.js
+++ b/src/hooks/useChatMessages.js
@@ -23,7 +23,7 @@ export function useChatMessages() {
           .from('chat_messages')
           .select('*')
           .eq('object_id', objectId)
-          .order('created_at', { ascending: true })
+          .order('created_at', { ascending: false })
 
         if (typeof limit === 'number') {
           if (typeof offset === 'number') {
@@ -35,6 +35,7 @@ export function useChatMessages() {
 
         const result = await query
         if (result.error) throw result.error
+        if (result.data) result.data.reverse()
         return result
       } catch (error) {
         await handleSupabaseError(error, navigate, 'Ошибка загрузки сообщений')

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -75,6 +75,21 @@ describe('ChatTab', () => {
     mockFetchMessages.mockResolvedValue({ data: mockMessages, error: null })
   })
 
+  it('отображает последнее сообщение после загрузки', async () => {
+    const manyMessages = Array.from({ length: 25 }, (_, i) => ({
+      id: `${i + 1}`,
+      object_id: '1',
+      sender: 'other@example.com',
+      content: `msg${i + 1}`,
+      created_at: new Date(Date.now() + i).toISOString(),
+    }))
+    mockFetchMessages.mockResolvedValueOnce({ data: manyMessages, error: null })
+
+    render(<ChatTab selected={{ id: '1' }} userEmail="me@example.com" />)
+
+    expect(await screen.findByText('msg25')).toBeInTheDocument()
+  })
+
   it('отображает сообщения и корректно определяет свои по e-mail', async () => {
     render(<ChatTab selected={{ id: '1' }} userEmail="me@example.com" />)
 


### PR DESCRIPTION
## Summary
- Загружаем сообщения из Supabase в порядке убывания и разворачиваем их перед возвратом
- При подгрузке более ранних сообщений добавляем их в начало списка без пересортировки
- Добавлен тест, проверяющий отображение последнего сообщения после инициализации

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2fe8aadf483249a6d1226bf3a93b4