### PR TITLE
Compute tasksHasMore from page limit and test Load More button

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -450,8 +450,9 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
       if (error.status === 403) toast.error('Недостаточно прав')
       else toast.error('Ошибка загрузки задач: ' + error.message)
     } else {
-      setTasks(data || [])
-      setTasksHasMore(false)
+      const tasksData = data || []
+      setTasks(tasksData)
+      setTasksHasMore(tasksData.length === PAGE_SIZE)
     }
     setLoadingTasks(false)
   }

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -100,6 +100,29 @@ describe('InventoryTabs', () => {
     expect(await screen.findByText('Задачи')).toBeInTheDocument()
   })
 
+  it('отображает кнопку «Загрузить ещё» при наличии дополнительных задач', async () => {
+    const tasks = Array.from({ length: 20 }, (_, i) => ({
+      id: `t${i}`,
+      title: `Task ${i}`,
+      status: 'запланировано',
+    }))
+    mockFetchTasksApi.mockResolvedValue({ data: tasks, error: null })
+
+    render(
+      <MemoryRouter>
+        <InventoryTabs
+          selected={selected}
+          onUpdateSelected={jest.fn()}
+          onTabChange={jest.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+
+    expect(await screen.findByText('Загрузить ещё')).toBeInTheDocument()
+  })
+
   it('создаёт и удаляет запись оборудования', async () => {
     mockInsertHardware.mockResolvedValue({
       data: {


### PR DESCRIPTION
## Summary
- calculate tasksHasMore using page size when fetching tasks
- add test ensuring "Load more" button shows when more tasks are available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a30fc8784c832495bc8cbc161c853f