### PR TITLE
Log fetchTasks errors for debugging

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -35,6 +35,7 @@ export function useTasks() {
       if (result.error) throw result.error
       return result
     } catch (error) {
+      console.error('fetchTasks failed', error)
       await handleSupabaseError(error, navigate, 'Ошибка загрузки задач')
       return { data: null, error }
     }


### PR DESCRIPTION
## Summary
- log Supabase errors to console in `fetchTasks`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31a5de7e483248769de56c6b35fb1