### PR TITLE
Обработка задач с полями assignee без executor

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -8,9 +8,9 @@ export function useTasks() {
   const fetchTasks = async (objectId) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
       const fallbackFields =
-        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+        'id, title, status, executor, executor_id, due_date, planned_date, plan_date, notes'
       const baseQuery = supabase
         .from('tasks')
         .select(baseFields)
@@ -24,11 +24,13 @@ export function useTasks() {
             .select(fallbackFields)
             .eq('object_id', objectId)
           if (!result.error && result.data) {
-            result.data = result.data.map((task) => ({
-              ...task,
-              assignee_id: null,
-              executor_id: null,
-            }))
+            result.data = result.data.map(
+              ({ executor, executor_id, ...rest }) => ({
+                ...rest,
+                assignee: executor,
+                assignee_id: executor_id,
+              }),
+            )
           }
         }
       }
@@ -44,9 +46,9 @@ export function useTasks() {
   const insertTask = async (data) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
       const fallbackFields =
-        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+        'id, title, status, executor, executor_id, due_date, planned_date, plan_date, notes'
       let result = await supabase
         .from('tasks')
         .insert([data])
@@ -59,7 +61,12 @@ export function useTasks() {
           .select(fallbackFields)
           .single()
         if (!result.error && result.data) {
-          result.data = { ...result.data, assignee_id: null, executor_id: null }
+          const { executor, executor_id, ...rest } = result.data
+          result.data = {
+            ...rest,
+            assignee: executor,
+            assignee_id: executor_id,
+          }
         }
       }
       if (result.error) throw result.error
@@ -73,9 +80,9 @@ export function useTasks() {
   const updateTask = async (id, data) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, executor, executor_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
       const fallbackFields =
-        'id, title, status, assignee, executor, due_date, planned_date, plan_date, notes'
+        'id, title, status, executor, executor_id, due_date, planned_date, plan_date, notes'
       let result = await supabase
         .from('tasks')
         .update(data)
@@ -90,7 +97,12 @@ export function useTasks() {
           .select(fallbackFields)
           .single()
         if (!result.error && result.data) {
-          result.data = { ...result.data, assignee_id: null, executor_id: null }
+          const { executor, executor_id, ...rest } = result.data
+          result.data = {
+            ...rest,
+            assignee: executor,
+            assignee_id: executor_id,
+          }
         }
       }
       if (result.error) throw result.error

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -64,7 +64,7 @@ describe('useTasks', () => {
     mockOrder.mockResolvedValueOnce({ data: null, error: { code: '42703' } })
     mockEqResults.push({ data: null, error: { code: '42703' } })
     mockEqResults.push({
-      data: [{ id: 1, title: 't', assignee: 'a', executor: 'e' }],
+      data: [{ id: 1, title: 't', executor: 'e', executor_id: 5 }],
       error: null,
     })
 
@@ -75,10 +75,8 @@ describe('useTasks', () => {
       {
         id: 1,
         title: 't',
-        assignee: 'a',
-        executor: 'e',
-        assignee_id: null,
-        executor_id: null,
+        assignee: 'e',
+        assignee_id: 5,
       },
     ])
     expect(mockSelect).toHaveBeenNthCalledWith(
@@ -87,7 +85,7 @@ describe('useTasks', () => {
     )
     expect(mockSelect).toHaveBeenNthCalledWith(
       2,
-      expect.not.stringContaining('assignee_id'),
+      expect.stringContaining('executor_id'),
     )
     expect(mockOrder).toHaveBeenCalledTimes(1)
     expect(mockHandleSupabaseError).not.toHaveBeenCalled()
@@ -101,9 +99,7 @@ describe('useTasks', () => {
           id: 1,
           title: 't',
           assignee: 'a',
-          executor: 'e',
           assignee_id: 10,
-          executor_id: 20,
         },
       ],
       error: null,
@@ -117,9 +113,7 @@ describe('useTasks', () => {
         id: 1,
         title: 't',
         assignee: 'a',
-        executor: 'e',
         assignee_id: 10,
-        executor_id: 20,
       },
     ])
     expect(mockSelect).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary
- убрать `executor`/`executor_id` из основных выборок задач
- при ошибке 42703 повторно запрашивать поля `executor`/`executor_id` и преобразовывать их в `assignee`
- обновить тесты под новые поля

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a320a81b9483249f0ca1dd49b2c9fb