### PR TITLE
feat: add CORS headers to cacheGet function

### DIFF
--- a/supabase/functions/cacheGet/index.ts
+++ b/supabase/functions/cacheGet/index.ts
@@ -2,23 +2,33 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { Redis } from 'https://deno.land/x/upstash_redis@v1.22.0/mod.ts'
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+}
+
 serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
   const url = new URL(req.url)
   const table = url.searchParams.get('table')
-  const allowedTables = ['profiles']
+  const allowedTables = ['profiles', 'objects']
   const id = url.searchParams.get('id')
 
   if (!table) {
     return new Response(JSON.stringify({ error: 'table is required' }), {
       status: 400,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
   if (!allowedTables.includes(table)) {
     return new Response(JSON.stringify({ error: 'table is not allowed' }), {
       status: 403,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
@@ -35,7 +45,7 @@ serve(async (req) => {
   if (userError || !userData?.user) {
     return new Response(JSON.stringify({ error: 'unauthorized' }), {
       status: 401,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
@@ -49,21 +59,25 @@ serve(async (req) => {
   if (req.method === 'DELETE') {
     await redis.del(key)
     return new Response(JSON.stringify({ status: 'invalidated' }), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
   if (req.method !== 'GET') {
     return new Response(JSON.stringify({ error: 'method not allowed' }), {
       status: 405,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
   const cached = await redis.get<string>(key)
   if (cached) {
     return new Response(cached, {
-      headers: { 'Content-Type': 'application/json', 'X-Cache': 'HIT' },
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json',
+        'X-Cache': 'HIT',
+      },
     })
   }
 
@@ -79,13 +93,17 @@ serve(async (req) => {
   if (error) {
     return new Response(JSON.stringify({ error: error.message }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   }
 
   await redis.set(key, JSON.stringify({ data }), { ex: 3600 })
 
   return new Response(JSON.stringify({ data }), {
-    headers: { 'Content-Type': 'application/json', 'X-Cache': 'MISS' },
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+      'X-Cache': 'MISS',
+    },
   })
 })


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding CORS headers and OPTIONS handling to cacheGet
- expand allowed tables to include objects and apply CORS headers to every response

## Testing
- `npm test`
- `npm run lint` *(fails: Insert `⏎` in src/hooks/useChat.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a32921e22c83248df57032ec379990