### PR TITLE
Обработка ошибок кеша схемы для задач

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -5,6 +5,10 @@ import { useNavigate } from 'react-router-dom'
 export function useTasks() {
   const navigate = useNavigate()
 
+  const isSchemaCacheError = (error) =>
+    error?.code === '42703' ||
+    error?.message?.toLowerCase?.().includes('schema cache')
+
   const fetchTasks = async (objectId) => {
     try {
       const baseFields =
@@ -16,9 +20,9 @@ export function useTasks() {
         .select(baseFields)
         .eq('object_id', objectId)
       let result = await baseQuery.order('created_at')
-      if (result.error?.code === '42703') {
+      if (isSchemaCacheError(result.error)) {
         result = await baseQuery
-        if (result.error?.code === '42703') {
+        if (isSchemaCacheError(result.error)) {
           result = await supabase
             .from('tasks')
             .select(fallbackFields)
@@ -54,7 +58,7 @@ export function useTasks() {
         .insert([data])
         .select(baseFields)
         .single()
-      if (result.error?.code === '42703') {
+      if (isSchemaCacheError(result.error)) {
         result = await supabase
           .from('tasks')
           .insert([data])
@@ -89,7 +93,7 @@ export function useTasks() {
         .eq('id', id)
         .select(baseFields)
         .single()
-      if (result.error?.code === '42703') {
+      if (isSchemaCacheError(result.error)) {
         result = await supabase
           .from('tasks')
           .update(data)

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -91,6 +91,43 @@ describe('useTasks', () => {
     expect(mockHandleSupabaseError).not.toHaveBeenCalled()
   })
 
+  it('использует fallback при устаревшем кеше схемы', async () => {
+    mockOrder.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'schema cache out of date' },
+    })
+    mockEqResults.push({
+      data: null,
+      error: { message: 'schema cache out of date' },
+    })
+    mockEqResults.push({
+      data: [{ id: 1, title: 't', executor: 'e', executor_id: 5 }],
+      error: null,
+    })
+
+    const { result } = renderHook(() => useTasks())
+    const { data, error } = await result.current.fetchTasks(1)
+    expect(error).toBeNull()
+    expect(data).toEqual([
+      {
+        id: 1,
+        title: 't',
+        assignee: 'e',
+        assignee_id: 5,
+      },
+    ])
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('assignee_id'),
+    )
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('executor_id'),
+    )
+    expect(mockOrder).toHaveBeenCalledTimes(1)
+    expect(mockHandleSupabaseError).not.toHaveBeenCalled()
+  })
+
   it('успешно загружает задачи без created_at', async () => {
     mockOrder.mockResolvedValueOnce({ data: null, error: { code: '42703' } })
     mockEqResults.push({


### PR DESCRIPTION
## Summary
- handle stale schema cache errors when loading tasks
- expand fallback logic to cover schema cache issues on insert/update
- add unit test for schema cache fallback

## Testing
- `npm test tests/useTasks.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a32923f6988324a00808d5d7bbbe0e