### PR TITLE
feat: add paginated task loading

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -127,6 +127,7 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
   const [taskDeleteId, setTaskDeleteId] = useState(null)
   const taskEffectRan = React.useRef(false)
   const [tasksError, setTasksError] = useState(null)
+  const [tasksPage, setTasksPage] = useState(0)
   const [tasksHasMore, setTasksHasMore] = useState(true)
   const [loadingTasks, setLoadingTasks] = useState(false)
 
@@ -220,11 +221,12 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
     setHardwarePage(0)
     setHardwareHasMore(true)
     setHardwareError(null)
+    setTasksPage(0)
     setTasksHasMore(true)
     setTasksError(null)
 
     fetchHardware(selected.id, 0)
-    fetchTasks(selected.id)
+    fetchTasks(selected.id, 0)
     fetchMessages(selected.id).then(({ data, error }) => {
       if (error) {
         if (error.status === 403) toast.error('Недостаточно прав')
@@ -443,21 +445,27 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
 
   // --- CRUD Задачи ---
 
-  async function fetchTasks(objectId) {
+  async function fetchTasks(objectId, offset = 0) {
     setLoadingTasks(true)
 
     setTasksError(null)
-    const { data, error } = await fetchTasksApi(objectId)
+    const { data, error } = await fetchTasksApi(objectId, offset, PAGE_SIZE)
     if (error) {
       setTasksError(error)
       if (error.status === 403) toast.error('Недостаточно прав')
       else toast.error('Ошибка загрузки задач: ' + error.message)
     } else {
       const tasksData = data || []
-      setTasks(tasksData)
+      setTasks((prev) => (offset === 0 ? tasksData : [...prev, ...tasksData]))
       setTasksHasMore(tasksData.length === PAGE_SIZE)
     }
     setLoadingTasks(false)
+  }
+
+  function loadMoreTasks() {
+    const nextPage = tasksPage + 1
+    setTasksPage(nextPage)
+    fetchTasks(selected.id, nextPage * PAGE_SIZE)
   }
 
   function openTaskModal(item = null) {
@@ -576,8 +584,9 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
         await fetchHardware(selected.id, 0)
       } else if (importTable === 'tasks') {
         setTasks([])
+        setTasksPage(0)
         setTasksHasMore(true)
-        await fetchTasks(selected.id)
+        await fetchTasks(selected.id, 0)
       }
     } catch (e) {
       toast.error(e.message)
@@ -905,7 +914,7 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
             {tasksHasMore && !loadingTasks && (
               <button
                 className="btn btn-outline btn-sm mt-2"
-                onClick={() => fetchTasks(selected.id)}
+                onClick={loadMoreTasks}
               >
                 Загрузить ещё
               </button>

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -9,7 +9,7 @@ export function useTasks() {
     error?.code === '42703' ||
     error?.message?.toLowerCase?.().includes('schema cache')
 
-  const fetchTasks = async (objectId) => {
+  const fetchTasks = async (objectId, offset = 0, limit = 20) => {
     try {
       const baseFields =
         'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
@@ -17,9 +17,11 @@ export function useTasks() {
         .from('tasks')
         .select(baseFields)
         .eq('object_id', objectId)
-      let result = await baseQuery.order('created_at')
+      let result = await baseQuery
+        .order('created_at')
+        .range(offset, offset + limit - 1)
       if (isSchemaCacheError(result.error)) {
-        result = await baseQuery
+        result = await baseQuery.range(offset, offset + limit - 1)
       }
       if (result.error) throw result.error
       return result

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -124,13 +124,20 @@ describe('InventoryTabs', () => {
     expect(await screen.findByText('Задачи не найдены')).toBeInTheDocument()
   })
 
-  it('отображает кнопку «Загрузить ещё» при наличии дополнительных задач', async () => {
-    const tasks = Array.from({ length: 20 }, (_, i) => ({
+  it('подгружает дополнительные задачи по кнопке «Загрузить ещё»', async () => {
+    const tasks1 = Array.from({ length: 20 }, (_, i) => ({
       id: `t${i}`,
       title: `Task ${i}`,
       status: 'запланировано',
     }))
-    mockFetchTasksApi.mockResolvedValue({ data: tasks, error: null })
+    const tasks2 = Array.from({ length: 5 }, (_, i) => ({
+      id: `t${i + 20}`,
+      title: `Task ${i + 20}`,
+      status: 'запланировано',
+    }))
+    mockFetchTasksApi
+      .mockResolvedValueOnce({ data: tasks1, error: null })
+      .mockResolvedValueOnce({ data: tasks2, error: null })
 
     render(
       <MemoryRouter>
@@ -144,7 +151,14 @@ describe('InventoryTabs', () => {
 
     fireEvent.click(screen.getAllByText(/Задачи/)[0])
 
-    expect(await screen.findByText('Загрузить ещё')).toBeInTheDocument()
+    const loadMoreBtn = await screen.findByText('Загрузить ещё')
+    fireEvent.click(loadMoreBtn)
+
+    await waitFor(() =>
+      expect(mockFetchTasksApi).toHaveBeenLastCalledWith(selected.id, 20, 20),
+    )
+    expect(await screen.findByText('Task 24')).toBeInTheDocument()
+    expect(screen.queryByText('Загрузить ещё')).not.toBeInTheDocument()
   })
 
   it('создаёт и удаляет запись оборудования', async () => {


### PR DESCRIPTION
## Summary
- add offset/limit to fetchTasks and query supabase with range
- paginate tasks in InventoryTabs with Load more button and page tracking
- update tests for new pagination behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a334a51ca08324a24e203ccdabb658