### PR TITLE
Использование только due_date для задач

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -468,7 +468,7 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
         status: item.status,
         assignee: item.assignee || '',
         assignee_id: item.assignee_id || '',
-        due_date: item.due_date || item.planned_date || item.plan_date || '',
+        due_date: item.due_date || '',
         notes: item.notes || '',
       })
     } else {
@@ -489,8 +489,7 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
       status: data.status,
       assignee: data.assignee || null,
       assignee_id: data.assignee_id || null,
-      planned_date: data.due_date || null,
-      plan_date: data.due_date || null,
+      due_date: data.due_date || null,
       notes: data.notes || null,
     }
     let res
@@ -1044,16 +1043,10 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
                         <strong>Исполнитель:</strong> {viewingTask.assignee}
                       </p>
                     )}
-                    {(viewingTask.due_date ||
-                      viewingTask.planned_date ||
-                      viewingTask.plan_date) && (
+                    {viewingTask.due_date && (
                       <p>
                         <strong>Дата:</strong>{' '}
-                        {formatDate(
-                          viewingTask.due_date ||
-                            viewingTask.planned_date ||
-                            viewingTask.plan_date,
-                        )}
+                        {formatDate(viewingTask.due_date)}
                       </p>
                     )}
                     <p>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -29,10 +29,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
 
   const assignee = useMemo(() => item.assignee, [item.assignee])
 
-  const dueDate = useMemo(
-    () => item.due_date || item.planned_date || item.plan_date,
-    [item.due_date, item.planned_date, item.plan_date],
-  )
+  const dueDate = useMemo(() => item.due_date, [item.due_date])
 
   const handleEdit = useCallback(
     (e) => {
@@ -100,8 +97,6 @@ TaskCard.propTypes = {
     status: PropTypes.string.isRequired,
     assignee: PropTypes.string,
     due_date: PropTypes.string,
-    planned_date: PropTypes.string,
-    plan_date: PropTypes.string,
   }).isRequired,
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -12,7 +12,7 @@ export function useTasks() {
   const fetchTasks = async (objectId) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, notes'
       const baseQuery = supabase
         .from('tasks')
         .select(baseFields)
@@ -33,10 +33,15 @@ export function useTasks() {
   const insertTask = async (data) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, notes'
+      const {
+        planned_date: _planned_date,
+        plan_date: _plan_date,
+        ...taskData
+      } = data
       const result = await supabase
         .from('tasks')
-        .insert([data])
+        .insert([taskData])
         .select(baseFields)
         .single()
       if (result.error) throw result.error
@@ -50,10 +55,15 @@ export function useTasks() {
   const updateTask = async (id, data) => {
     try {
       const baseFields =
-        'id, title, status, assignee, assignee_id, due_date, planned_date, plan_date, notes'
+        'id, title, status, assignee, assignee_id, due_date, notes'
+      const {
+        planned_date: _planned_date,
+        plan_date: _plan_date,
+        ...taskData
+      } = data
       const result = await supabase
         .from('tasks')
-        .update(data)
+        .update(taskData)
         .eq('id', id)
         .select(baseFields)
         .single()

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -2,6 +2,8 @@ var mockInsertHardware
 var mockDeleteHardware
 var mockFetchHardwareApi
 var mockFetchTasksApi
+var mockInsertTask
+var mockUpdateTask
 var mockFetchMessages
 var mockSubscribeToTasks
 var taskHandler
@@ -33,6 +35,8 @@ jest.mock('../src/hooks/useHardware.js', () => {
 
 jest.mock('../src/hooks/useTasks.js', () => {
   mockFetchTasksApi = jest.fn().mockResolvedValue({ data: [], error: null })
+  mockInsertTask = jest.fn()
+  mockUpdateTask = jest.fn()
   mockSubscribeToTasks = jest.fn((_, handler) => {
     taskHandler = handler
     return jest.fn()
@@ -40,8 +44,8 @@ jest.mock('../src/hooks/useTasks.js', () => {
   return {
     useTasks: () => ({
       fetchTasks: mockFetchTasksApi,
-      insertTask: jest.fn(),
-      updateTask: jest.fn(),
+      insertTask: mockInsertTask,
+      updateTask: mockUpdateTask,
       deleteTask: jest.fn(),
       subscribeToTasks: mockSubscribeToTasks,
     }),
@@ -87,6 +91,8 @@ describe('InventoryTabs', () => {
     jest.clearAllMocks()
     mockFetchHardwareApi.mockResolvedValue({ data: [], error: null })
     mockFetchTasksApi.mockResolvedValue({ data: [], error: null })
+    mockInsertTask.mockResolvedValue({ data: null, error: null })
+    mockUpdateTask.mockResolvedValue({ data: null, error: null })
     taskHandler = null
   })
 
@@ -217,6 +223,141 @@ describe('InventoryTabs', () => {
     )
   })
 
+  it('добавляет задачу с due_date', async () => {
+    mockInsertTask.mockResolvedValue({
+      data: {
+        id: 't1',
+        title: 'Новая задача',
+        status: 'запланировано',
+        assignee: null,
+        assignee_id: null,
+        due_date: '2024-05-10',
+        notes: null,
+      },
+      error: null,
+    })
+
+    render(
+      <MemoryRouter>
+        <InventoryTabs
+          selected={selected}
+          onUpdateSelected={jest.fn()}
+          onTabChange={jest.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+    fireEvent.click(await screen.findByText('Добавить задачу'))
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'Новая задача' },
+    })
+    fireEvent.click(screen.getByText('📅'))
+    const dateInput = document.querySelector('input[type="date"]')
+    fireEvent.change(dateInput, { target: { value: '2024-05-10' } })
+    fireEvent.click(screen.getByText('Сохранить'))
+
+    await waitFor(() => expect(mockInsertTask).toHaveBeenCalled())
+
+    const payload = mockInsertTask.mock.calls[0][0]
+    expect(payload).toEqual({
+      object_id: selected.id,
+      title: 'Новая задача',
+      status: 'запланировано',
+      assignee: null,
+      assignee_id: null,
+      due_date: '2024-05-10',
+      notes: null,
+    })
+
+    expect(await screen.findByText('Новая задача')).toBeInTheDocument()
+  })
+
+  it('редактирует задачу с due_date', async () => {
+    mockFetchTasksApi.mockResolvedValue({
+      data: [
+        {
+          id: 't1',
+          title: 'Старая задача',
+          status: 'запланировано',
+          assignee: null,
+          assignee_id: null,
+          due_date: '2024-05-10',
+          notes: null,
+        },
+      ],
+      error: null,
+    })
+    mockUpdateTask.mockResolvedValue({
+      data: {
+        id: 't1',
+        title: 'Старая задача',
+        status: 'запланировано',
+        assignee: null,
+        assignee_id: null,
+        due_date: '2024-05-15',
+        notes: null,
+      },
+      error: null,
+    })
+
+    render(
+      <MemoryRouter>
+        <InventoryTabs
+          selected={selected}
+          onUpdateSelected={jest.fn()}
+          onTabChange={jest.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+    expect(await screen.findByText('Старая задача')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('Редактировать'))
+    fireEvent.click(screen.getByText('📅'))
+    const dateInput = document.querySelector('input[type="date"]')
+    fireEvent.change(dateInput, { target: { value: '2024-05-15' } })
+    fireEvent.click(screen.getByText('Сохранить'))
+
+    await waitFor(() => expect(mockUpdateTask).toHaveBeenCalled())
+
+    const payload = mockUpdateTask.mock.calls[0][1]
+    expect(payload.due_date).toBe('2024-05-15')
+    expect(payload).not.toHaveProperty('planned_date')
+    expect(payload).not.toHaveProperty('plan_date')
+  })
+
+  it('просматривает задачу с due_date', async () => {
+    mockFetchTasksApi.mockResolvedValue({
+      data: [
+        {
+          id: 't1',
+          title: 'Просмотр',
+          status: 'запланировано',
+          due_date: '2024-05-10',
+        },
+      ],
+      error: null,
+    })
+
+    render(
+      <MemoryRouter>
+        <InventoryTabs
+          selected={selected}
+          onUpdateSelected={jest.fn()}
+          onTabChange={jest.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+    fireEvent.click(await screen.findByText('Просмотр'))
+
+    expect(await screen.findByText('10.05.2024')).toBeInTheDocument()
+  })
+
   it('синхронизирует список задач при обновлении и удалении', async () => {
     mockFetchTasksApi.mockResolvedValue({
       data: [{ id: 't1', title: 'Задача 1', status: 'запланировано' }],
@@ -233,7 +374,7 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByText(/Задачи/))
+    fireEvent.click(screen.getAllByText(/Задачи/)[0])
     expect(await screen.findByText('Задача 1')).toBeInTheDocument()
 
     act(() => {


### PR DESCRIPTION
## Summary
- очистка хуков и компонентов от `planned_date`/`plan_date`
- унификация отображения задач по полю `due_date`
- тесты добавления, редактирования и просмотра задач

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a334a34b3c8324ad3162e5a0178138