### PR TITLE
Повторный order при ошибках schema cache

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -21,7 +21,9 @@ export function useTasks() {
         .order('created_at')
         .range(offset, offset + limit - 1)
       if (isSchemaCacheError(result.error)) {
-        result = await baseQuery.range(offset, offset + limit - 1)
+        result = await baseQuery
+          .order('created_at')
+          .range(offset, offset + limit - 1)
       }
       if (result.error) throw result.error
       return result

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -50,22 +50,23 @@ describe('useTasks', () => {
     )
   })
 
-  it('успешно загружает задачи без created_at', async () => {
-    mockRangeOrder.mockResolvedValueOnce({
-      data: null,
-      error: { code: '42703' },
-    })
-    mockRangeBase.mockResolvedValueOnce({
-      data: [
-        {
-          id: 1,
-          title: 't',
-          assignee: 'a',
-          assignee_id: 10,
-        },
-      ],
-      error: null,
-    })
+  it('успешно загружает задачи при ошибке schema cache', async () => {
+    mockRangeOrder
+      .mockResolvedValueOnce({
+        data: null,
+        error: { code: '42703' },
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            title: 't',
+            assignee: 'a',
+            assignee_id: 10,
+          },
+        ],
+        error: null,
+      })
 
     const { result } = renderHook(() => useTasks())
     const { data, error } = await result.current.fetchTasks(1, 0, 20)
@@ -79,8 +80,8 @@ describe('useTasks', () => {
       },
     ])
     expect(mockSelect).toHaveBeenCalledTimes(1)
-    expect(mockOrder).toHaveBeenCalledTimes(1)
-    expect(mockRangeOrder).toHaveBeenCalledTimes(1)
-    expect(mockRangeBase).toHaveBeenCalledTimes(1)
+    expect(mockOrder).toHaveBeenCalledTimes(2)
+    expect(mockRangeOrder).toHaveBeenCalledTimes(2)
+    expect(mockRangeBase).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
## Summary
- Повторно применён `.order('created_at')` в fallback-запросе `fetchTasks`
- Обновлён тест `useTasks` для проверки одинаковой сортировки при ошибке schema cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a714ba55f0832494dc90c6d9d2e923