### PR TITLE
refactor: remove redundant error check in confirmDeleteHardware

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -432,11 +432,6 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
         ? toast.error('Недостаточно прав')
         : toast.error('Ошибка удаления: ' + error.message)
 
-    if (error) {
-      await handleSupabaseError(error, navigate, 'Ошибка удаления')
-      return
-    }
-
     setHardware((prev) => prev.filter((h) => h.id !== id))
     setHwDeleteId(null)
   }


### PR DESCRIPTION
## Summary
- simplify hardware deletion error handling by removing unreachable block

## Testing
- `npx jest --config jest.config.js --ci --reporters=summary`


------
https://chatgpt.com/codex/tasks/task_e_68a714bc098883249a635fe4918da164