### PR TITLE
feat: вынесена авторизация в сервис

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,7 +1,8 @@
 import { createContext, useEffect, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { supabase, isSupabaseConfigured } from '../supabaseClient'
-import { apiBaseUrl, isApiConfigured } from '../apiConfig'
+import { isApiConfigured } from '../apiConfig'
+import { fetchSession, fetchRole } from '../services/authService'
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext({ user: null, role: null })
@@ -19,135 +20,47 @@ export function AuthProvider({ children }) {
       toast.error('Роль недоступна: API не сконфигурирован')
     }
 
-    let cacheGetAvailable = null
-
-    const checkCacheGetAvailability = async () => {
-      if (cacheGetAvailable !== null) return cacheGetAvailable
-      try {
-        const res = await fetch(`${apiBaseUrl}/functions/v1/cacheGet`, {
-          method: 'OPTIONS',
-        })
-        cacheGetAvailable = res.status !== 404
-      } catch {
-        cacheGetAvailable = false
-      }
-      return cacheGetAvailable
-    }
-
-    const fetchRole = async (id) => {
-      if (!(await checkCacheGetAvailability())) {
-        try {
-          const { data, error } = await supabase
-            .from('profiles')
-            .select('role')
-            .eq('id', id)
-            .maybeSingle()
-          if (error) throw error
-          return { role: data?.role ?? null }
-        } catch (error) {
-          return { error }
-        }
-      }
-      try {
-        const res = await fetch(
-          `${apiBaseUrl}/functions/v1/cacheGet?table=${encodeURIComponent('profiles')}&id=${encodeURIComponent(id)}`,
-        )
-        if (!res.ok) {
-          let message
-          try {
-            const errorBody = await res.clone().json()
-            message = errorBody?.message
-          } catch {
-            // ignore JSON parse errors
-          }
-          if (!message) {
-            message = await res.text()
-          }
-          if (
-            res.status === 404 ||
-            message?.includes('Requested function was not found')
-          ) {
-            cacheGetAvailable = false
-            try {
-              const { data, error: fallbackError } = await supabase
-                .from('profiles')
-                .select('role')
-                .eq('id', id)
-                .maybeSingle()
-              if (fallbackError) throw fallbackError
-              return { role: data?.role ?? null }
-            } catch (error) {
-              return { error }
-            }
-          }
-          throw new Error(message)
-        }
-        const body = await res.json()
-        return { role: body.data?.role ?? null }
-      } catch (error) {
-        return { error }
-      }
-    }
-
-    const fetchSession = async () => {
-      try {
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession()
-        if (error) throw error
-        const currentUser = session?.user ?? null
-        setUser(currentUser)
-
-        if (currentUser) {
-          if (isApiConfigured) {
-            const { role: fetchedRole, error: roleError } = await fetchRole(
-              currentUser.id,
-            )
-            if (roleError) {
-              console.error('Ошибка получения роли:', roleError)
-              toast.error('Ошибка получения роли: ' + roleError.message)
-              setRole(null)
-            } else if (fetchedRole === null) {
-              setRole(null)
-            } else {
-              setRole(fetchedRole)
-            }
-          } else {
-            setRole(null)
-          }
-        } else {
-          setRole(null)
-        }
-      } catch (error) {
-        console.error('Ошибка получения сессии:', error)
-        toast.error('Ошибка получения сессии: ' + error.message)
+    const loadSession = async () => {
+      const { user: currentUser, error: sessionError } = await fetchSession()
+      if (sessionError) {
+        console.error('Ошибка получения сессии:', sessionError)
+        toast.error('Ошибка получения сессии: ' + sessionError.message)
         setUser(null)
+        setRole(null)
+        return
+      }
+      setUser(currentUser)
+      if (currentUser && isApiConfigured) {
+        const { role: fetchedRole, error: roleError } = await fetchRole(
+          currentUser.id,
+        )
+        if (roleError) {
+          console.error('Ошибка получения роли:', roleError)
+          toast.error('Ошибка получения роли: ' + roleError.message)
+          setRole(null)
+        } else {
+          setRole(fetchedRole)
+        }
+      } else {
         setRole(null)
       }
     }
 
-    fetchSession()
+    loadSession()
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (_event, session) => {
       const currentUser = session?.user ?? null
       setUser(currentUser)
-      if (currentUser) {
-        if (isApiConfigured) {
-          const { role: fetchedRole, error } = await fetchRole(currentUser.id)
-          if (error) {
-            console.error('Ошибка получения роли:', error)
-            toast.error('Ошибка получения роли: ' + error.message)
-            setRole(null)
-          } else if (fetchedRole === null) {
-            setRole(null)
-          } else {
-            setRole(fetchedRole)
-          }
-        } else {
+      if (currentUser && isApiConfigured) {
+        const { role: fetchedRole, error } = await fetchRole(currentUser.id)
+        if (error) {
+          console.error('Ошибка получения роли:', error)
+          toast.error('Ошибка получения роли: ' + error.message)
           setRole(null)
+        } else {
+          setRole(fetchedRole)
         }
       } else {
         setRole(null)

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,98 @@
+import { supabase } from '../supabaseClient'
+import { apiBaseUrl, isApiConfigured } from '../apiConfig'
+
+const DEFAULT_TIMEOUT = 10000
+
+function withTimeout(promise, timeout = DEFAULT_TIMEOUT) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Request timed out')), timeout),
+    ),
+  ])
+}
+
+function formatError(error) {
+  return { message: error.message }
+}
+
+let cacheGetAvailable = null
+
+export async function checkCacheGet({ timeout } = {}) {
+  if (!isApiConfigured) return false
+  if (cacheGetAvailable !== null) return cacheGetAvailable
+  try {
+    const res = await withTimeout(
+      fetch(`${apiBaseUrl}/functions/v1/cacheGet`, { method: 'OPTIONS' }),
+      timeout,
+    )
+    cacheGetAvailable = res.status !== 404
+  } catch {
+    cacheGetAvailable = false
+  }
+  return cacheGetAvailable
+}
+
+export async function fetchRole(id, { timeout } = {}) {
+  if (!(await checkCacheGet({ timeout }))) {
+    try {
+      const { data, error } = await withTimeout(
+        supabase.from('profiles').select('role').eq('id', id).maybeSingle(),
+        timeout,
+      )
+      if (error) throw error
+      return { role: data?.role ?? null }
+    } catch (error) {
+      return { error: formatError(error) }
+    }
+  }
+  try {
+    const res = await withTimeout(
+      fetch(
+        `${apiBaseUrl}/functions/v1/cacheGet?table=${encodeURIComponent('profiles')}&id=${encodeURIComponent(id)}`,
+      ),
+      timeout,
+    )
+    if (!res.ok) {
+      let message
+      try {
+        const errorBody = await res.clone().json()
+        message = errorBody?.message
+      } catch {
+        // ignore JSON parse errors
+      }
+      if (!message) {
+        message = await res.text()
+      }
+      if (
+        res.status === 404 ||
+        message?.includes('Requested function was not found')
+      ) {
+        cacheGetAvailable = false
+        return fetchRole(id, { timeout })
+      }
+      throw new Error(message)
+    }
+    const body = await res.json()
+    return { role: body.data?.role ?? null }
+  } catch (error) {
+    return { error: formatError(error) }
+  }
+}
+
+export async function fetchSession({ timeout } = {}) {
+  try {
+    const {
+      data: { session },
+      error,
+    } = await withTimeout(supabase.auth.getSession(), timeout)
+    if (error) throw error
+    return { user: session?.user ?? null }
+  } catch (error) {
+    return { error: formatError(error) }
+  }
+}
+
+export function __resetCache() {
+  cacheGetAvailable = null
+}

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+const mockGetSession = jest.fn()
+const mockMaybeSingle = jest.fn()
+const mockEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }))
+const mockSelect = jest.fn(() => ({ eq: mockEq }))
+const mockFrom = jest.fn(() => ({ select: mockSelect }))
+
+jest.mock('../src/supabaseClient.js', () => ({
+  supabase: {
+    auth: { getSession: mockGetSession },
+    from: mockFrom,
+  },
+  isSupabaseConfigured: true,
+}))
+
+jest.mock('../src/apiConfig.js', () => ({
+  apiBaseUrl: 'http://localhost',
+  isApiConfigured: true,
+}))
+
+let fetchSession, fetchRole, __resetCache
+
+beforeEach(async () => {
+  jest.resetModules()
+  globalThis.fetch = jest.fn()
+  const mod = await import('../src/services/authService.js')
+  fetchSession = mod.fetchSession
+  fetchRole = mod.fetchRole
+  __resetCache = mod.__resetCache
+  __resetCache()
+  mockGetSession.mockReset()
+  mockMaybeSingle.mockReset()
+  mockEq.mockClear()
+  mockSelect.mockClear()
+  mockFrom.mockClear()
+})
+
+describe('authService', () => {
+  it('fetchSession возвращает пользователя', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      data: { session: { user: { id: 1 } } },
+      error: null,
+    })
+    const { user, error } = await fetchSession()
+    expect(user).toEqual({ id: 1 })
+    expect(error).toBeUndefined()
+  })
+
+  it('fetchSession возвращает ошибку', async () => {
+    const err = new Error('fail')
+    mockGetSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: err,
+    })
+    const { user, error } = await fetchSession()
+    expect(user).toBeUndefined()
+    expect(error).toEqual({ message: 'fail' })
+  })
+
+  it('fetchRole использует cacheGet при доступности', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({ status: 200 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { role: 'admin' } }),
+      })
+    const { role, error } = await fetchRole('123')
+    expect(error).toBeUndefined()
+    expect(role).toBe('admin')
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('fetchRole падает на supabase при отсутствии cacheGet', async () => {
+    globalThis.fetch.mockResolvedValueOnce({ status: 404 })
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { role: 'user' },
+      error: null,
+    })
+    const { role, error } = await fetchRole('1')
+    expect(error).toBeUndefined()
+    expect(role).toBe('user')
+    expect(mockMaybeSingle).toHaveBeenCalled()
+  })
+
+  it('fetchRole возвращает ошибку supabase', async () => {
+    globalThis.fetch.mockResolvedValueOnce({ status: 404 })
+    const err = new Error('db')
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: err })
+    const { error } = await fetchRole('1')
+    expect(error).toEqual({ message: 'db' })
+  })
+})


### PR DESCRIPTION
## Summary
- добавить сервис `authService` с функциями `fetchSession`, `fetchRole` и проверкой `cacheGet`
- заменить прямые вызовы Supabase и API в `AuthContext` на использование сервиса
- реализовать обработку ошибок и таймауты
- покрыть сервис модульными тестами

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a715b4fc488324a94b8c6a9f3ec13e