### PR TITLE
feat: добавить логгер и обновить тесты

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,9 +1,11 @@
+import logger from './utils/logger'
+
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
 
 export const isApiConfigured = Boolean(apiBaseUrl)
 
 if (!isApiConfigured) {
-  console.error(
+  logger.error(
     'Не задана переменная окружения VITE_API_BASE_URL. Приложение работает в ограниченном режиме.',
   )
 }

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import logger from '../utils/logger'
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -12,7 +13,7 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    console.error('ErrorBoundary caught an error', error, errorInfo)
+    logger.error('ErrorBoundary caught an error', error, errorInfo)
   }
 
   render() {

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -2,6 +2,7 @@ import { createContext, useEffect, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { supabase, isSupabaseConfigured } from '../supabaseClient'
 import { apiBaseUrl, isApiConfigured } from '../apiConfig'
+import logger from '../utils/logger'
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext({ user: null, role: null })
@@ -13,7 +14,7 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     if (!isSupabaseConfigured) return
     if (!isApiConfigured) {
-      console.error(
+      logger.error(
         'Не задана переменная окружения VITE_API_BASE_URL. Авторизация через API недоступна.',
       )
       toast.error('Роль недоступна: API не сконфигурирован')
@@ -105,7 +106,7 @@ export function AuthProvider({ children }) {
               currentUser.id,
             )
             if (roleError) {
-              console.error('Ошибка получения роли:', roleError)
+              logger.error('Ошибка получения роли:', roleError)
               toast.error('Ошибка получения роли: ' + roleError.message)
               setRole(null)
             } else if (fetchedRole === null) {
@@ -120,7 +121,7 @@ export function AuthProvider({ children }) {
           setRole(null)
         }
       } catch (error) {
-        console.error('Ошибка получения сессии:', error)
+        logger.error('Ошибка получения сессии:', error)
         toast.error('Ошибка получения сессии: ' + error.message)
         setUser(null)
         setRole(null)
@@ -138,7 +139,7 @@ export function AuthProvider({ children }) {
         if (isApiConfigured) {
           const { role: fetchedRole, error } = await fetchRole(currentUser.id)
           if (error) {
-            console.error('Ошибка получения роли:', error)
+            logger.error('Ошибка получения роли:', error)
             toast.error('Ошибка получения роли: ' + error.message)
             setRole(null)
           } else if (fetchedRole === null) {

--- a/src/hooks/useObjects.js
+++ b/src/hooks/useObjects.js
@@ -1,9 +1,10 @@
 import { supabase } from '../supabaseClient'
 import { apiBaseUrl, isApiConfigured } from '../apiConfig'
+import logger from '../utils/logger'
 
 export function useObjects() {
   if (!isApiConfigured) {
-    console.error(
+    logger.error(
       'Не задана переменная окружения VITE_API_BASE_URL. Работа с объектами недоступна.',
     )
     const error = new Error('API не настроен')

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,6 +1,7 @@
 import { supabase } from '../supabaseClient'
 import { handleSupabaseError } from '../utils/handleSupabaseError'
 import { useNavigate } from 'react-router-dom'
+import logger from '../utils/logger'
 
 export function useTasks() {
   const navigate = useNavigate()
@@ -26,7 +27,7 @@ export function useTasks() {
       if (result.error) throw result.error
       return result
     } catch (error) {
-      console.error('fetchTasks failed', error)
+      logger.error('fetchTasks failed', error)
       await handleSupabaseError(error, navigate, 'Ошибка загрузки задач')
       return { data: null, error }
     }

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useSupabaseAuth } from '../hooks/useSupabaseAuth'
 import { useNavigate } from 'react-router-dom'
+import logger from '../utils/logger'
 
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
@@ -45,7 +46,7 @@ export default function AuthPage() {
       error instanceof TypeError ||
       (error.message && error.message.toLowerCase().includes('failed to fetch'))
     ) {
-      console.error(error)
+      logger.error(error)
       return 'Не удалось подключиться к серверу. Попробуйте позже.'
     }
     return error.message
@@ -101,7 +102,7 @@ export default function AuthPage() {
           }
         }))
       } catch (error) {
-        console.error(error)
+        logger.error(error)
         setUserError('Не удалось получить сессию. Попробуйте позже.')
         return
       }

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -17,6 +17,7 @@ import { Navigate, useNavigate } from 'react-router-dom'
 import { handleSupabaseError } from '../utils/handleSupabaseError'
 import { useAuth } from '../hooks/useAuth'
 import { exportInventory, importInventory } from '../utils/exportImport'
+import logger from '../utils/logger'
 
 const SELECTED_OBJECT_KEY = 'selectedObjectId'
 const NOTIF_KEY = 'objectNotifications'
@@ -148,7 +149,7 @@ export default function DashboardPage() {
         setFetchError('Недостаточно прав')
         return
       }
-      console.error('Ошибка загрузки объектов:', error)
+      logger.error('Ошибка загрузки объектов:', error)
       toast.error('Ошибка загрузки объектов: ' + error.message)
 
       await handleSupabaseError(error, navigate, 'Ошибка загрузки объектов')

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import logger from './utils/logger'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -8,20 +9,20 @@ export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseKey)
 let supabase
 
 if (!isSupabaseConfigured) {
-  console.error(
+  logger.error(
     'Не заданы переменные окружения VITE_SUPABASE_URL или VITE_SUPABASE_ANON_KEY.',
   )
   const handler = {
     get() {
       return new Proxy(() => {
-        console.error(
+        logger.error(
           'Попытка обращения к Supabase при отсутствии конфигурации.',
         )
         return Promise.reject(new Error('Supabase не инициализирован'))
       }, handler)
     },
     apply() {
-      console.error('Попытка обращения к Supabase при отсутствии конфигурации.')
+      logger.error('Попытка обращения к Supabase при отсутствии конфигурации.')
       return Promise.reject(new Error('Supabase не инициализирован'))
     },
   }

--- a/src/utils/exportImport.js
+++ b/src/utils/exportImport.js
@@ -1,5 +1,6 @@
 import { supabase } from '../supabaseClient'
 import { apiBaseUrl, isApiConfigured } from '../apiConfig'
+import logger from './logger'
 export async function exportInventory() {
   const { data, error } = await supabase.functions.invoke('export-inventory')
   if (error) throw error
@@ -14,7 +15,7 @@ export async function importInventory(file) {
 }
 export async function exportTable(table, format) {
   if (!isApiConfigured) {
-    console.error(
+    logger.error(
       'Не задана переменная окружения VITE_API_BASE_URL. Экспорт невозможен.',
     )
     throw new Error('API не настроен')
@@ -29,7 +30,7 @@ export async function exportTable(table, format) {
     }
     return await res.blob()
   } catch (err) {
-    console.error('exportTable error:', err)
+    logger.error('exportTable error:', err)
     throw err
   }
 }
@@ -37,7 +38,7 @@ export async function importTable(table, file) {
   const formData = new FormData()
   formData.append('file', file)
   if (!isApiConfigured) {
-    console.error(
+    logger.error(
       'Не задана переменная окружения VITE_API_BASE_URL. Импорт невозможен.',
     )
     throw new Error('API не настроен')
@@ -57,7 +58,7 @@ export async function importTable(table, file) {
       errors: result.errors ?? [],
     }
   } catch (err) {
-    console.error('importTable error:', err)
+    logger.error('importTable error:', err)
     throw err
   }
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,35 @@
+/* globals process */
+
+const levels = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+}
+
+function getEnvLevel() {
+  const level =
+    import.meta.env?.VITE_LOG_LEVEL ||
+    process?.env?.LOG_LEVEL ||
+    process?.env?.VITE_LOG_LEVEL
+  return level || 'info'
+}
+
+function shouldLog(level) {
+  const envLevel = levels[getEnvLevel()] ?? levels.info
+  return envLevel >= levels[level]
+}
+
+const logger = {
+  info: (...args) => {
+    if (shouldLog('info')) console.info(...args)
+  },
+  warn: (...args) => {
+    if (shouldLog('warn')) console.warn(...args)
+  },
+  error: (...args) => {
+    if (shouldLog('error')) console.error(...args)
+  },
+}
+
+export default logger

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -1,3 +1,5 @@
+import logger from './logger'
+
 let audioCtx
 function playTone(frequency) {
   if (typeof window === 'undefined') return
@@ -22,7 +24,7 @@ export function requestNotificationPermission() {
     try {
       Notification.requestPermission()
     } catch (err) {
-      console.error('Notification permission error:', err)
+      logger.error('Notification permission error:', err)
     }
   }
 }
@@ -34,7 +36,7 @@ export function pushNotification(title, body) {
     try {
       new Notification(title, { body })
     } catch (err) {
-      console.error('Notification error:', err)
+      logger.error('Notification error:', err)
     }
   }
 }

--- a/tests/AuthContext.test.jsx
+++ b/tests/AuthContext.test.jsx
@@ -3,6 +3,7 @@ import { describe, it, expect, jest } from '@jest/globals'
 import { useContext } from 'react'
 import { AuthProvider, AuthContext } from '../src/context/AuthContext.jsx'
 import { toast } from 'react-hot-toast'
+import logger from '../src/utils/logger.js'
 
 const mockGetSession = jest.fn()
 const mockOnAuthStateChange = jest.fn()
@@ -44,7 +45,7 @@ describe('AuthContext', () => {
         },
       }),
     )
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleSpy = jest.spyOn(logger, 'error').mockImplementation(() => {})
 
     render(
       <AuthProvider>

--- a/tests/ErrorBoundary.test.jsx
+++ b/tests/ErrorBoundary.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import logger from '../src/utils/logger.js'
 
 function ProblemComponent() {
   throw new Error('Test error')
@@ -8,7 +9,7 @@ function ProblemComponent() {
 
 describe('ErrorBoundary', () => {
   it('перехватывает ошибки и отображает резервный UI', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {})
 
     render(
       <ErrorBoundary>

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,63 @@
+/* eslint-env node */
+/* globals process */
+import logger from '../src/utils/logger.js'
+
+describe('logger', () => {
+  let infoSpy
+  let warnSpy
+  let errorSpy
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    process.env = { ...originalEnv }
+  })
+
+  test('по умолчанию логирует все уровни', () => {
+    delete process.env.LOG_LEVEL
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(infoSpy).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  test('уровень warn отключает info', () => {
+    process.env.LOG_LEVEL = 'warn'
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  test('уровень error отключает warn и info', () => {
+    process.env.LOG_LEVEL = 'error'
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  test('уровень none отключает все', () => {
+    process.env.LOG_LEVEL = 'none'
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- добавить утилиту логгирования с уровнями и настройкой через переменные окружения
- заменить console.error на вызовы логгера
- написать и обновить тесты под новый логгер

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a715bc3e688324b7aa3f95ad4ad256