### PR TITLE
feat: add chat error handling

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -28,6 +28,7 @@ function ChatTab({ selected = null, userEmail }) {
     handleKeyDown,
     fileInputRef,
     scrollRef,
+    loadError,
   } = useChat({ objectId, userEmail, search: searchQuery })
 
   const handleFileChange = useCallback(
@@ -96,66 +97,79 @@ function ChatTab({ selected = null, userEmail }) {
         ref={scrollRef}
         className="flex-1 overflow-y-auto p-4 space-y-3 bg-base-200 rounded-2xl"
       >
-        {hasMore && (
+        {loadError ? (
           <div className="text-center">
-            <button className="btn btn-sm" onClick={() => loadMore()}>
-              Загрузить ещё
+            <p className="mb-2 text-error">Не удалось загрузить сообщения</p>
+            <button className="btn btn-sm" onClick={() => loadMore(true)}>
+              Повторить
             </button>
           </div>
-        )}
-        {messages.length === 0 ? (
-          searchQuery ? (
-            <div className="text-sm text-gray-400">Сообщения не найдены</div>
-          ) : (
-            <div className="text-sm text-gray-400">
-              Сообщений пока нет — напиши первым.
-            </div>
-          )
         ) : (
-          messages.map((m) => {
-            const isOwn =
-              (m.sender || '').trim().toLowerCase() ===
-              (userEmail || '').trim().toLowerCase()
-            const dt = new Date(m.created_at)
-            const date = dt.toLocaleDateString()
-            const time = dt.toLocaleTimeString([], {
-              hour: '2-digit',
-              minute: '2-digit',
-            })
-            return (
-              <div
-                key={m.id}
-                className={`chat ${isOwn ? 'chat-end' : 'chat-start'}`}
-              >
-                {!isOwn && (
-                  <div className="chat-header">{m.sender || 'user'}</div>
-                )}
-                <div
-                  className={`chat-bubble whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
-                    isOwn
-                      ? 'bg-primary text-primary-content'
-                      : 'bg-base-100 text-base-content'
-                  }`}
-                >
-                  {m.content && (
-                    <span className="whitespace-pre-wrap break-words">
-                      {linkifyText(m.content)}
-                    </span>
-                  )}
-                  {m.file_url && (
-                    <div className="mt-2">
-                      <AttachmentPreview url={m.file_url} />
-                    </div>
-                  )}
-                  <span className="self-end mt-1 text-xs opacity-60">
-                    {`${date} ${time}`}
-                    {m.read_at ? ' ✓' : ''}
-                    {m._optimistic ? ' • отправка…' : ''}
-                  </span>
-                </div>
+          <>
+            {hasMore && (
+              <div className="text-center">
+                <button className="btn btn-sm" onClick={() => loadMore()}>
+                  Загрузить ещё
+                </button>
               </div>
-            )
-          })
+            )}
+            {messages.length === 0 ? (
+              searchQuery ? (
+                <div className="text-sm text-gray-400">
+                  Сообщения не найдены
+                </div>
+              ) : (
+                <div className="text-sm text-gray-400">
+                  Сообщений пока нет — напиши первым.
+                </div>
+              )
+            ) : (
+              messages.map((m) => {
+                const isOwn =
+                  (m.sender || '').trim().toLowerCase() ===
+                  (userEmail || '').trim().toLowerCase()
+                const dt = new Date(m.created_at)
+                const date = dt.toLocaleDateString()
+                const time = dt.toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })
+                return (
+                  <div
+                    key={m.id}
+                    className={`chat ${isOwn ? 'chat-end' : 'chat-start'}`}
+                  >
+                    {!isOwn && (
+                      <div className="chat-header">{m.sender || 'user'}</div>
+                    )}
+                    <div
+                      className={`chat-bubble whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
+                        isOwn
+                          ? 'bg-primary text-primary-content'
+                          : 'bg-base-100 text-base-content'
+                      }`}
+                    >
+                      {m.content && (
+                        <span className="whitespace-pre-wrap break-words">
+                          {linkifyText(m.content)}
+                        </span>
+                      )}
+                      {m.file_url && (
+                        <div className="mt-2">
+                          <AttachmentPreview url={m.file_url} />
+                        </div>
+                      )}
+                      <span className="self-end mt-1 text-xs opacity-60">
+                        {`${date} ${time}`}
+                        {m.read_at ? ' ✓' : ''}
+                        {m._optimistic ? ' • отправка…' : ''}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </>
         )}
       </div>
 

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -10,6 +10,7 @@ export default function useChat({ objectId, userEmail, search }) {
   const [sending, setSending] = useState(false)
   const [file, setFile] = useState(null)
   const [filePreview, setFilePreview] = useState(null)
+  const [loadError, setLoadError] = useState(null)
   const scrollRef = useRef(null)
   const channelRef = useRef(null)
   const fileInputRef = useRef(null)
@@ -33,9 +34,16 @@ export default function useChat({ objectId, userEmail, search }) {
       const { data, error } = await fetchMessages(objectId, params)
       if (currentSearch !== activeSearchRef.current) return
       if (error) {
+        console.error('loadMore error', {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        })
+        setLoadError(error)
         await handleSupabaseError(error, null, 'Ошибка загрузки сообщений')
-        return
+        return { error }
       }
+      setLoadError(null)
       offsetRef.current += data?.length || 0
       if (replace) {
         setMessages(data || [])
@@ -267,6 +275,7 @@ export default function useChat({ objectId, userEmail, search }) {
     fileInputRef,
     scrollRef,
     markMessagesAsRead,
+    loadError,
   }
 }
 

--- a/tests/useChatMessages.test.js
+++ b/tests/useChatMessages.test.js
@@ -7,6 +7,10 @@ jest.mock('../src/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
 }))
 
+jest.mock('react-hot-toast', () => ({
+  toast: { error: jest.fn() },
+}))
+
 jest.mock('react-router-dom', () => ({
   useNavigate: () => jest.fn(),
 }))


### PR DESCRIPTION
## Summary
- handle TypeError when Supabase is unavailable and log diagnostics
- expose chat loading errors with retry UI
- log detailed error information for chat operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73f71f5d88324a1bc3018ee717a1a