### PR TITLE
feat: add auth loading state

### DIFF
--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -2,9 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import Spinner from './Spinner'
 
 export default function PrivateRoute({ children }) {
-  const { user } = useAuth()
+  const { user, isLoading } = useAuth()
+  if (isLoading) {
+    return <Spinner />
+  }
   return user ? children : <Navigate to="/auth" replace />
 }
 

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -3,9 +3,10 @@ import { AuthContext } from '../context/AuthContext'
 import { ROLE_ADMIN, ROLE_MANAGER, ROLE_USER } from '../constants/roles.js'
 
 export function useAuth() {
-  const { user, role } = useContext(AuthContext)
+  const { user, role, isLoading } = useContext(AuthContext)
   return {
     user,
+    isLoading,
     isAdmin: role === ROLE_ADMIN,
     isManager: role === ROLE_MANAGER,
     isUser: role === ROLE_USER,

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -5,19 +5,15 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useSupabaseAuth } from '../hooks/useSupabaseAuth'
 import { useNavigate } from 'react-router-dom'
 import logger from '../utils/logger'
+import { useAuth } from '../hooks/useAuth'
 
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
   const [userError, setUserError] = useState(null)
   const [info, setInfo] = useState(null)
   const navigate = useNavigate()
-  const {
-    getSession,
-    onAuthStateChange,
-    signUp,
-    signIn,
-    error: authError,
-  } = useSupabaseAuth()
+  const { signUp, signIn, error: authError } = useSupabaseAuth()
+  const { user, isLoading } = useAuth()
 
   const schema = z
     .object({
@@ -83,38 +79,10 @@ export default function AuthPage() {
   }
 
   useEffect(() => {
-    let isMounted = true
-    let subscription
-
-    const checkSession = async () => {
-      try {
-        const {
-          data: { session },
-        } = await getSession()
-        if (session && isMounted) {
-          navigate('/')
-        }
-        ;({
-          data: { subscription },
-        } = onAuthStateChange((_event, session) => {
-          if (session) {
-            navigate('/')
-          }
-        }))
-      } catch (error) {
-        logger.error(error)
-        setUserError('Не удалось получить сессию. Попробуйте позже.')
-        return
-      }
+    if (!isLoading && user) {
+      navigate('/')
     }
-
-    checkSession()
-
-    return () => {
-      isMounted = false
-      subscription?.unsubscribe()
-    }
-  }, [navigate])
+  }, [user, isLoading, navigate])
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add `isLoading` to auth context and hook
- show spinner in `PrivateRoute` while session loads
- adjust auth page redirect to account for session loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a74f4fb9208324b3d971dbc9b8be3f