### PR TITLE
feat: virtualize task list rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-hook-form": "^7.62.0",
         "react-hot-toast": "^2.5.2",
         "react-router-dom": "^6.30.1",
+        "react-window": "^1.8.10",
         "uuid": "^11.1.0",
         "zod": "^4.0.15"
       },
@@ -1972,7 +1973,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
       "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -16162,6 +16162,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -18671,6 +18677,23 @@
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hook-form": "^7.62.0",
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^6.30.1",
+    "react-window": "^1.8.10",
     "uuid": "^11.1.0",
     "zod": "^4.0.15"
   },
@@ -67,10 +68,10 @@
     "prettier": "^3.4.2",
     "start-server-and-test": "^2.0.4",
     "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.2",
     "vite": "^4.0.0",
     "vite-plugin-compression": "^0.5.1",
     "vitest": "^1.6.0",
-    "typescript": "^5.4.2",
     "webpagetest": "^0.7.6"
   },
   "lint-staged": {

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -7,7 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { supabase } from '../supabaseClient'
 import { handleSupabaseError } from '../utils/handleSupabaseError'
 import HardwareCard from './HardwareCard'
-import TaskCard from './TaskCard'
+import VirtualizedTaskList from './VirtualizedTaskList'
 import ChatTab from './ChatTab'
 import { PlusIcon, ChatBubbleOvalLeftIcon } from '@heroicons/react/24/outline'
 import { linkifyText } from '../utils/linkify'
@@ -886,17 +886,12 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
             {!loadingTasks && !tasksError && (
               <>
                 {tasks.length === 0 && <p>Задачи не найдены</p>}
-                <div className="grid gap-2 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-                  {tasks.map((t) => (
-                    <TaskCard
-                      key={t.id}
-                      item={t}
-                      onView={() => openTaskView(t)}
-                      onEdit={() => openTaskModal(t)}
-                      onDelete={() => askDeleteTask(t.id)}
-                    />
-                  ))}
-                </div>
+                <VirtualizedTaskList
+                  tasks={tasks}
+                  onView={openTaskView}
+                  onEdit={openTaskModal}
+                  onDelete={askDeleteTask}
+                />
               </>
             )}
             {tasksHasMore && !loadingTasks && (

--- a/src/components/VirtualizedTaskList.jsx
+++ b/src/components/VirtualizedTaskList.jsx
@@ -1,0 +1,54 @@
+import { FixedSizeList as List } from 'react-window'
+import PropTypes from 'prop-types'
+import { forwardRef } from 'react'
+import TaskCard from './TaskCard'
+
+function VirtualizedTaskList({
+  tasks,
+  onView,
+  onEdit,
+  onDelete,
+  height = 400,
+  itemSize = 120,
+}) {
+  const Row = ({ index, style }) => {
+    const task = tasks[index]
+    return (
+      <div style={style}>
+        <TaskCard
+          item={task}
+          onView={() => onView(task)}
+          onEdit={() => onEdit(task)}
+          onDelete={() => onDelete(task.id)}
+        />
+      </div>
+    )
+  }
+
+  const Outer = forwardRef((props, ref) => (
+    <div data-testid="task-list" ref={ref} {...props} />
+  ))
+
+  return (
+    <List
+      height={height}
+      itemCount={tasks.length}
+      itemSize={itemSize}
+      width="100%"
+      outerElementType={Outer}
+    >
+      {Row}
+    </List>
+  )
+}
+
+VirtualizedTaskList.propTypes = {
+  tasks: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onView: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  height: PropTypes.number,
+  itemSize: PropTypes.number,
+}
+
+export default VirtualizedTaskList

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -163,7 +163,8 @@ describe('InventoryTabs', () => {
     await waitFor(() =>
       expect(mockFetchTasksApi).toHaveBeenLastCalledWith(selected.id, 20, 20),
     )
-    expect(await screen.findByText('Task 24')).toBeInTheDocument()
+    const list = screen.getByTestId('task-list')
+    expect(list.firstChild.style.height).toBe('3000px')
     expect(screen.queryByText('Загрузить ещё')).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- use react-window for task list virtualization
- replace static task mapping with VirtualizedTaskList
- adjust tests for virtualized task loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75eb5c330832481b5041c702e1782