### PR TITLE
Удалён плагин daisyui из конфигурации Tailwind

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,3 @@
-import daisyui from 'daisyui'
-
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
@@ -21,8 +19,5 @@ export default {
       },
     },
   },
-  plugins: [daisyui],
-  daisyui: {
-    themes: ['light', 'dark', 'cupcake', 'retro', 'cyberpunk'],
-  },
+  plugins: [],
 }


### PR DESCRIPTION
## Summary
- убрать плагин daisyui из конфигурации Tailwind

## Testing
- `npm test` *(fails: loadTasks is not a function; Cannot access 'mockFetchMessages' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3ea1dfa08324bed6774e04b37192