### PR TITLE
Refactor ConfirmModal to use dialog components

### DIFF
--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -1,5 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
 
 export default function ConfirmModal({
   open,
@@ -11,22 +18,25 @@ export default function ConfirmModal({
   onConfirm,
   onCancel,
 }) {
-  if (!open) return null
   return (
-    <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="modal-box relative w-full max-w-sm">
-        {title && <h3 className="font-bold text-lg mb-4">{title}</h3>}
-        {message && <p className="mb-4">{message}</p>}
-        <div className="modal-action flex space-x-2">
+    <Dialog open={open} onOpenChange={onCancel}>
+      <DialogContent>
+        {title && (
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </DialogHeader>
+        )}
+        {message && <p>{message}</p>}
+        <DialogFooter>
           <button className={`btn ${confirmClass}`} onClick={onConfirm}>
             {confirmLabel}
           </button>
           <button className="btn" onClick={onCancel}>
             {cancelLabel}
           </button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onOpenChange?.(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={handleOverlayClick}
+    >
+      {children}
+    </div>
+  )
+}
+Dialog.propTypes = {
+  open: PropTypes.bool,
+  onOpenChange: PropTypes.func,
+  children: PropTypes.node,
+}
+
+export function DialogContent({ children }) {
+  return (
+    <div
+      className="bg-base-100 p-4 rounded"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>
+  )
+}
+DialogContent.propTypes = {
+  children: PropTypes.node,
+}
+
+export function DialogHeader({ children }) {
+  return <div className="mb-4">{children}</div>
+}
+DialogHeader.propTypes = {
+  children: PropTypes.node,
+}
+
+export function DialogTitle({ children }) {
+  return <h3 className="font-bold text-lg">{children}</h3>
+}
+DialogTitle.propTypes = {
+  children: PropTypes.node,
+}
+
+export function DialogFooter({ children }) {
+  return <div className="mt-4 flex space-x-2 justify-end">{children}</div>
+}
+DialogFooter.propTypes = {
+  children: PropTypes.node,
+}


### PR DESCRIPTION
## Summary
- replace custom modal markup with shared Dialog components
- implement minimal Dialog UI module

## Testing
- `npm test` *(fails: loadTasks is not a function, mockFetchMessages not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3fb5f5e48324aee6ec35cf981c7a