### PR TITLE
feat: migrate object modal to Dialog

### DIFF
--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={() => onOpenChange(false)}
+      />
+      {children}
+    </div>
+  )
+}
+
+export function DialogContent({ children }) {
+  return (
+    <div className="relative z-50 w-full max-w-md rounded-md bg-base-100 p-4 shadow-lg">
+      {children}
+    </div>
+  )
+}
+
+export function DialogHeader({ children }) {
+  return <div className="mb-4">{children}</div>
+}
+
+export function DialogTitle({ children }) {
+  return <h3 className="font-bold text-lg">{children}</h3>
+}
+
+export function DialogFooter({ children }) {
+  return <div className="mt-4 flex justify-end space-x-2">{children}</div>
+}
+
+Dialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onOpenChange: PropTypes.func.isRequired,
+  children: PropTypes.node,
+}
+
+DialogContent.propTypes = {
+  children: PropTypes.node,
+}
+
+DialogHeader.propTypes = {
+  children: PropTypes.node,
+}
+
+DialogTitle.propTypes = {
+  children: PropTypes.node,
+}
+
+DialogFooter.propTypes = {
+  children: PropTypes.node,
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -8,11 +8,16 @@ import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline'
 import ThemeToggle from '../components/ThemeToggle'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import { exportInventory, importInventory } from '../utils/exportImport'
-import logger from '../utils/logger'
 import { useObjectList } from '../hooks/useObjectList'
 import { useObjectNotifications } from '../hooks/useObjectNotifications'
 import { useDashboardModals } from '../hooks/useDashboardModals'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
 
 export default function DashboardPage() {
   const { user, isAdmin, isManager } = useAuth()
@@ -210,38 +215,32 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        {isObjectModalOpen && (
-          <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-            <div className="modal-box relative w-full max-w-md">
-              <button
-                className="btn btn-circle btn-md md:btn-sm absolute right-2 top-2"
-                onClick={closeObjectModal}
-              >
-                ✕
-              </button>
-              <h3 className="font-bold text-lg mb-4">
+        <Dialog open={isObjectModalOpen} onOpenChange={closeObjectModal}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
                 {editingObject ? 'Редактировать объект' : 'Добавить объект'}
-              </h3>
-              <div className="space-y-4">
-                <input
-                  type="text"
-                  className="input input-bordered w-full"
-                  placeholder="Название"
-                  value={objectName}
-                  onChange={(e) => setObjectName(e.target.value)}
-                />
-              </div>
-              <div className="modal-action flex space-x-2">
-                <button className="btn btn-primary" onClick={onSaveObject}>
-                  Сохранить
-                </button>
-                <button className="btn btn-ghost" onClick={closeObjectModal}>
-                  Отмена
-                </button>
-              </div>
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <input
+                type="text"
+                className="input input-bordered w-full"
+                placeholder="Название"
+                value={objectName}
+                onChange={(e) => setObjectName(e.target.value)}
+              />
             </div>
-          </div>
-        )}
+            <DialogFooter>
+              <button className="btn btn-primary" onClick={onSaveObject}>
+                Сохранить
+              </button>
+              <button className="btn btn-ghost" onClick={closeObjectModal}>
+                Отмена
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <ConfirmModal
           open={!!deleteCandidate}


### PR DESCRIPTION
## Summary
- use Dialog components to manage object modal
- add basic Dialog implementation

## Testing
- `npm test` *(fails: mockFetchMessages is not a function, loadTasks is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3fb8f9148324bc7083f425640de9