### PR TITLE
refactor: use UI Card components in HardwareCard

### DIFF
--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -1,40 +1,42 @@
 // src/components/HardwareCard.jsx
 import React from 'react'
 import PropTypes from 'prop-types'
-import Card from './Card'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 
 export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
   return (
-    <Card className="flex justify-between items-center">
-      <div>
-        <div className="font-medium text-lg">{item.name}</div>
+    <Card>
+      <CardHeader>
+        <CardTitle>{item.name}</CardTitle>
         <div className="text-sm text-base-content/70 transition-colors">
           {item.location}
         </div>
+      </CardHeader>
+      <CardContent className="flex justify-between items-center">
         <div className="flex space-x-2 mt-1 text-sm">
           <span>Покупка: {item.purchase_status}</span>
           <span>Установка: {item.install_status}</span>
         </div>
-      </div>
-      {!!user && (
-        <div className="flex flex-col sm:flex-row gap-2">
-          <button
-            onClick={onEdit}
-            className="btn btn-sm btn-outline flex items-center gap-1 w-full sm:w-auto"
-          >
-            <PencilIcon className="w-4 h-4" />
-            Изменить
-          </button>
-          <button
-            onClick={onDelete}
-            className="btn btn-sm btn-error flex items-center gap-1 w-full sm:w-auto"
-          >
-            <TrashIcon className="w-4 h-4" />
-            Удалить
-          </button>
-        </div>
-      )}
+        {!!user && (
+          <div className="flex flex-col sm:flex-row gap-2">
+            <button
+              onClick={onEdit}
+              className="btn btn-sm btn-outline flex items-center gap-1 w-full sm:w-auto"
+            >
+              <PencilIcon className="w-4 h-4" />
+              Изменить
+            </button>
+            <button
+              onClick={onDelete}
+              className="btn btn-sm btn-error flex items-center gap-1 w-full sm:w-auto"
+            >
+              <TrashIcon className="w-4 h-4" />
+              Удалить
+            </button>
+          </div>
+        )}
+      </CardContent>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary
- restructure HardwareCard with CardHeader and CardContent from UI card package

## Testing
- `npm test` (fails: Could not locate module @/components/ui/card)
- `npm run lint` (fails: 41 errors, 5 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68ab3fc35d8c83248958442c388f939f