### PR TITLE
feat: refine chat message sending

### DIFF
--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -137,7 +137,6 @@ export default function useChat({ objectId, userEmail, search }) {
             setMessages((prev) => {
               const existingIndex = prev.findIndex(
                 (m) =>
-                  m._optimistic &&
                   m.client_generated_id === payload.new.client_generated_id,
               )
 
@@ -248,27 +247,50 @@ export default function useChat({ objectId, userEmail, search }) {
     offsetRef.current += 1
     setMessages((prev) => [...prev, optimistic])
 
-    const { error } = await supabase.from('chat_messages').insert([
-      {
-        object_id: objectId,
-        sender: userEmail,
-        content: newMessage.trim(),
-        client_generated_id: optimisticId,
-      },
-    ])
+    optimisticTimersRef.current[optimisticId] = setTimeout(() => {
+      setMessages((prev) =>
+        prev.filter((m) => m.client_generated_id !== optimisticId),
+      )
+      offsetRef.current -= 1
+      delete optimisticTimersRef.current[optimisticId]
+    }, 5000)
+
+    const { data, error } = await supabase
+      .from('chat_messages')
+      .insert([
+        {
+          object_id: objectId,
+          sender: userEmail,
+          content: newMessage.trim(),
+          client_generated_id: optimisticId,
+        },
+      ])
+      .select()
+      .single()
+
+    const timer = optimisticTimersRef.current[optimisticId]
 
     if (error) {
       await handleSupabaseError(error, null, 'Ошибка отправки')
-      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
+      if (timer) {
+        clearTimeout(timer)
+        delete optimisticTimersRef.current[optimisticId]
+      }
+      setMessages((prev) =>
+        prev.filter((m) => m.client_generated_id !== optimisticId),
+      )
       offsetRef.current -= 1
     } else {
-      optimisticTimersRef.current[optimisticId] = setTimeout(() => {
-        setMessages((prev) =>
-          prev.filter((m) => m.client_generated_id !== optimisticId),
-        )
-        offsetRef.current -= 1
+      if (timer) {
+        clearTimeout(timer)
         delete optimisticTimersRef.current[optimisticId]
-      }, 5000)
+      }
+      setMessages((prev) =>
+        [
+          ...prev.filter((m) => m.client_generated_id !== optimisticId),
+          data,
+        ].sort(sortByCreatedAt),
+      )
     }
     setNewMessage('')
     setSending(false)

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -23,9 +23,19 @@ var mockInsert
 var mockFetchMessages
 
 jest.mock('../src/supabaseClient.js', () => {
-  mockInsert = jest.fn(() =>
-    Promise.resolve({ data: { id: '3' }, error: null }),
-  )
+  mockInsert = jest.fn((records) => {
+    const record = records[0]
+    return {
+      select: jest.fn(() => ({
+        single: jest.fn(() =>
+          Promise.resolve({
+            data: { id: '3', created_at: new Date().toISOString(), ...record },
+            error: null,
+          }),
+        ),
+      })),
+    }
+  })
   const mockUpdate = jest.fn(() => ({
     is: jest.fn(() => ({
       eq: jest.fn(() => ({

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -17,7 +17,19 @@ const updateChain = {
   })),
 }
 
-const insertFn = jest.fn(() => Promise.resolve({ error: null }))
+const insertFn = jest.fn((records) => {
+  const record = records[0]
+  return {
+    select: jest.fn(() => ({
+      single: jest.fn(() =>
+        Promise.resolve({
+          data: { id: '10', created_at: new Date().toISOString(), ...record },
+          error: null,
+        }),
+      ),
+    })),
+  }
+})
 
 mockSupabase = {
   from: jest.fn(() => ({
@@ -178,8 +190,7 @@ describe('useChat markMessagesAsRead', () => {
     })
 
     expect(result.current.messages).toHaveLength(2)
-    const secondOptimistic = result.current.messages.find((m) => m._optimistic)
-    const secondId = secondOptimistic.client_generated_id
+    const secondId = result.current.messages[1].client_generated_id
 
     act(() => {
       onPayload({


### PR DESCRIPTION
## Summary
- запрашивать полную запись сообщения через select().single()
- очищать оптимистичное сообщение и связанные таймеры после успешной отправки
- обновить тестовые заглушки для новой логики отправки

## Testing
- `npm test tests/useChat.test.jsx tests/ChatTab.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab3fcbf7e4832483f219a5a24387a5