### PR TITLE
prevent duplicate chat inserts

### DIFF
--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -135,6 +135,10 @@ export default function useChat({ objectId, userEmail, search }) {
         (payload) => {
           if (payload.eventType === 'INSERT') {
             setMessages((prev) => {
+              if (prev.some((m) => m.id === payload.new.id)) {
+                return prev
+              }
+
               const existingIndex = prev.findIndex(
                 (m) =>
                   m._optimistic &&

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -198,4 +198,27 @@ describe('useChat markMessagesAsRead', () => {
     expect(result.current.messages.filter((m) => m._optimistic)).toHaveLength(0)
     expect(result.current.messages).toHaveLength(2)
   })
+
+  it('игнорирует повторные INSERT события с существующим id', async () => {
+    mockFetchMessages.mockReset()
+    mockFetchMessages
+      .mockResolvedValueOnce({ data: page1, error: null })
+      .mockResolvedValue({ data: [], error: null })
+
+    const { result } = renderHook(() =>
+      useChat({ objectId: '1', userEmail: 'me@example.com' }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.messages).toHaveLength(page1.length),
+    )
+
+    const prevMessages = result.current.messages
+    act(() => {
+      onPayload({ eventType: 'INSERT', new: { ...page1[0] } })
+    })
+
+    expect(result.current.messages).toBe(prevMessages)
+    expect(result.current.messages).toHaveLength(page1.length)
+  })
 })


### PR DESCRIPTION
## Summary
- avoid adding duplicate chat messages when receiving an INSERT event that already exists
- test ignoring duplicate chat inserts

## Testing
- `npm test tests/useChat.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab3fccc2448324934247fbf0ed038c