### PR TITLE
Ограничение ширины сообщений в чате

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -143,7 +143,7 @@ function ChatTab({ selected = null, userEmail }) {
                       <div className="chat-header">{m.sender || 'user'}</div>
                     )}
                     <div
-                      className={`chat-bubble whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
+                      className={`chat-bubble max-w-[80%] sm:max-w-[60%] whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
                         isOwn
                           ? 'bg-primary text-primary-content'
                           : 'bg-base-100 text-base-content'


### PR DESCRIPTION
## Summary
- ограничена ширина блока сообщений в ChatTab через классы Tailwind

## Testing
- `npm test` *(failed: 2 failed, 19 passed)*
- `npm run test:e2e` *(failed: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3fcda03c83249f09baf111f97bef