### PR TITLE
Добавлены тесты для модальных окон

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@redocly/cli": "^2.0.5",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.1.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vheemstra/vite-plugin-imagemin": "^2.2.0",
@@ -5942,6 +5943,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tokenizer/token": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@redocly/cli": "^2.0.5",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vheemstra/vite-plugin-imagemin": "^2.2.0",

--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -15,7 +15,6 @@ import {
 
 import { Button } from '@/components/ui/button'
 
-
 export default function AccountModal({ user, onClose, onUpdated }) {
   const [username, setUsername] = useState(user.user_metadata?.username || '')
   const [saving, setSaving] = useState(false)
@@ -35,59 +34,32 @@ export default function AccountModal({ user, onClose, onUpdated }) {
   }
 
   return (
-
     <Dialog open onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Редактирование аккаунта</DialogTitle>
         </DialogHeader>
-
-    <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="modal-box relative w-full max-w-md p-4 max-h-screen overflow-y-auto">
-        <Button
-          size="icon"
-          className="absolute right-2 top-2"
-          onClick={onClose}
-        >
-          ✕
-        </Button>
-        <h3 className="font-bold text-lg mb-4">Редактирование аккаунта</h3>
-
         <div className="space-y-4">
-          <div className="form-control">
-            <Label className="label">
-              <span className="label-text">Никнейм</span>
-            </Label>
+          <div className="grid gap-2">
+            <Label htmlFor="username">Никнейм</Label>
             <Input
-              type="text"
-              className="input input-bordered w-full"
+              id="username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
+              autoFocus
             />
           </div>
         </div>
-
         <DialogFooter>
-          <button className="btn btn-primary" onClick={save} disabled={saving}>
-
-        <div className="modal-action flex space-x-2">
           <Button onClick={save} disabled={saving}>
-
             Сохранить
           </Button>
           <Button variant="ghost" onClick={onClose}>
             Отмена
-
-          </button>
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-
-          </Button>
-        </div>
-      </div>
-    </div>
-
   )
 }
 

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Button } from '@/components/ui/button'
-
 import {
   Dialog,
   DialogContent,
@@ -10,7 +9,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-
 
 export default function ConfirmModal({
   open,
@@ -23,20 +21,6 @@ export default function ConfirmModal({
   onCancel,
 }) {
   return (
-
-    <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="modal-box relative w-full max-w-sm">
-        {title && <h3 className="font-bold text-lg mb-4">{title}</h3>}
-        {message && <p className="mb-4">{message}</p>}
-        <div className="modal-action flex space-x-2">
-          <Button variant={confirmVariant} onClick={onConfirm}>
-            {confirmLabel}
-          </Button>
-          <Button onClick={onCancel}>{cancelLabel}</Button>
-        </div>
-      </div>
-    </div>
-
     <Dialog open={open} onOpenChange={onCancel}>
       <DialogContent>
         {title && (
@@ -46,16 +30,15 @@ export default function ConfirmModal({
         )}
         {message && <p>{message}</p>}
         <DialogFooter>
-          <button className={`btn ${confirmClass}`} onClick={onConfirm}>
+          <Button autoFocus variant={confirmVariant} onClick={onConfirm}>
             {confirmLabel}
-          </button>
-          <button className="btn" onClick={onCancel}>
+          </Button>
+          <Button variant="ghost" onClick={onCancel}>
             {cancelLabel}
-          </button>
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-
   )
 }
 

--- a/src/components/__tests__/AccountModal.test.jsx
+++ b/src/components/__tests__/AccountModal.test.jsx
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+import AccountModal from '../AccountModal.jsx'
+
+const mockUpdate = jest.fn()
+
+jest.mock('../../hooks/useAccount', () => ({
+  useAccount: () => ({ updateProfile: mockUpdate }),
+}))
+
+jest.mock('react-hot-toast', () => ({ toast: { error: jest.fn() } }))
+
+describe('AccountModal', () => {
+  const user = { user_metadata: { username: 'old' } }
+
+  beforeEach(() => {
+    mockUpdate.mockResolvedValue({ data: { user }, error: null })
+  })
+
+  test('ставит фокус на поле и отменяет', async () => {
+    const onClose = jest.fn()
+    render(<AccountModal user={user} onClose={onClose} onUpdated={jest.fn()} />)
+
+    expect(screen.getByLabelText('Никнейм')).toHaveFocus()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Отмена' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test('сохраняет изменения', async () => {
+    const onClose = jest.fn()
+    const onUpdated = jest.fn()
+    render(<AccountModal user={user} onClose={onClose} onUpdated={onUpdated} />)
+
+    await userEvent.clear(screen.getByLabelText('Никнейм'))
+    await userEvent.type(screen.getByLabelText('Никнейм'), 'newname')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    expect(mockUpdate).toHaveBeenCalledWith({ username: 'newname' })
+    expect(onUpdated).toHaveBeenCalledWith(user)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/ConfirmModal.test.jsx
+++ b/src/components/__tests__/ConfirmModal.test.jsx
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, jest } from '@jest/globals'
+
+import ConfirmModal from '../ConfirmModal.jsx'
+
+describe('ConfirmModal', () => {
+  test('открывается, обрабатывает кнопки и фокус', async () => {
+    const onConfirm = jest.fn()
+    const onCancel = jest.fn()
+
+    render(
+      <ConfirmModal
+        open
+        title="Подтверждение"
+        message="Вы уверены?"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+
+    const confirmBtn = screen.getByRole('button', { name: 'OK' })
+    expect(confirmBtn).toHaveFocus()
+
+    await userEvent.click(confirmBtn)
+    expect(onConfirm).toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Отмена' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  test('не отображается, когда закрыт', () => {
+    render(
+      <ConfirmModal open={false} onConfirm={() => {}} onCancel={() => {}} />,
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -71,28 +70,3 @@ Button.propTypes = {
 }
 
 export { Button }
-
-import PropTypes from 'prop-types'
-
-export function Button({
-  size = 'default',
-  variant = 'primary',
-  className = '',
-  ...props
-}) {
-  const sizeClass = size === 'sm' ? 'btn-sm' : size === 'lg' ? 'btn-lg' : ''
-  const variantClass = variant ? `btn-${variant}` : ''
-  const combined = ['btn', sizeClass, variantClass, className]
-    .filter(Boolean)
-    .join(' ')
-  return <button className={combined} {...props} />
-}
-
-Button.propTypes = {
-  size: PropTypes.oneOf(['sm', 'lg', 'default']),
-  variant: PropTypes.string,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  onClick: PropTypes.func,
-}
-

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,19 +1,4 @@
 import React from 'react'
-
-
-export function Dialog({ open, onOpenChange, children }) {
-  if (!open) return null
-  return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
-      onClick={() => onOpenChange && onOpenChange(false)}
-    >
-      {React.Children.map(children, (child) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child, { onOpenChange })
-          : child,
-      )}
-
 import PropTypes from 'prop-types'
 
 export function Dialog({ open, onOpenChange, children, ...props }) {
@@ -27,27 +12,17 @@ export function Dialog({ open, onOpenChange, children, ...props }) {
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center"
       onClick={handleClick}
       {...props}
     >
-      <div
-        className="absolute inset-0 bg-black/50"
-        onClick={() => onOpenChange(false)}
-      />
+      <div className="absolute inset-0 bg-black/50" />
       {children}
-
     </div>
   )
 }
-
-
-export function DialogContent({ children, className = '' }) {
-  const stop = (e) => e.stopPropagation()
-  return (
-    <div
-      className={`relative w-full max-w-md p-4 max-h-screen overflow-y-auto bg-base-100 rounded shadow ${className}`}
-      onClick={stop}
 
 Dialog.propTypes = {
   open: PropTypes.bool.isRequired,
@@ -57,31 +32,15 @@ Dialog.propTypes = {
 
 export function DialogContent({ children, ...props }) {
   return (
-    <div 
+    <div
       className="relative z-50 w-full max-w-md rounded-md bg-base-100 p-4 shadow-lg"
       onClick={(e) => e.stopPropagation()}
       {...props}
-
     >
       {children}
     </div>
   )
 }
-
-
-export function DialogHeader({ children, className = '' }) {
-  return <div className={`mb-4 ${className}`}>{children}</div>
-}
-
-export function DialogTitle({ children, className = '' }) {
-  return <h3 className={`font-bold text-lg ${className}`}>{children}</h3>
-}
-
-export function DialogFooter({ children, className = '' }) {
-  return <div className={`mt-4 flex space-x-2 ${className}`}>{children}</div>
-}
-
-export default Dialog
 
 DialogContent.propTypes = {
   children: PropTypes.node,
@@ -103,12 +62,8 @@ DialogTitle.propTypes = {
   children: PropTypes.node,
 }
 
-export function DialogFooter({ children, ...props }) {
-  return (
-    <div className="mt-2 text-right" {...props}>
-      {children}
-    </div>
-  )
+export function DialogFooter({ children }) {
+  return <div className="mt-4 flex space-x-2">{children}</div>
 }
 
 DialogFooter.propTypes = {
@@ -116,4 +71,3 @@ DialogFooter.propTypes = {
 }
 
 export default Dialog
-

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -1,7 +1,9 @@
 // Tests for InventoryTabs component
 import '@testing-library/jest-dom'
 
-var mockLoadHardware, mockFetchHardwareApi, mockFetchMessages, mockNavigate
+/* eslint-env jest */
+
+var mockLoadHardware, mockFetchMessages, mockNavigate
 
 jest.mock('../src/hooks/usePersistedForm.js', () => () => ({
   register: jest.fn(),
@@ -10,11 +12,8 @@ jest.mock('../src/hooks/usePersistedForm.js', () => () => ({
   formState: { errors: {} },
 }))
 
-jest.mock('../src/components/ConfirmModal.jsx', () => () => null)
-
 jest.mock('../src/hooks/useHardware.js', () => {
   mockLoadHardware = jest.fn().mockResolvedValue({ data: [], error: null })
-  mockFetchHardwareApi = jest.fn().mockResolvedValue({ data: [], error: null })
 
   return {
     useHardware: () => ({
@@ -95,12 +94,12 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByText(/Железо/))
+    fireEvent.click(screen.getByRole('tab', { name: 'Железо' }))
     expect(await screen.findByText('Оборудование')).toBeInTheDocument()
 
-    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+    fireEvent.click(screen.getByRole('tab', { name: 'Задачи' }))
     expect(
-      await screen.findByRole('heading', { name: /Задачи/ }),
+      await screen.findByRole('heading', { name: 'Задачи' }),
     ).toBeInTheDocument()
   })
 
@@ -117,7 +116,7 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getAllByText(/Задачи/)[0])
+    fireEvent.click(screen.getByRole('tab', { name: 'Задачи' }))
     expect(
       await screen.findByText('Нет данных. Нажмите «Добавить».'),
     ).toBeInTheDocument()
@@ -136,7 +135,7 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByText(/Чат/))
+    fireEvent.click(screen.getByRole('tab', { name: 'Чат' }))
     expect(screen.getByText(/Чат для/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- добавлены рабочие компоненты ConfirmModal и AccountModal
- написаны тесты для ConfirmModal и AccountModal
- обновлены селекторы вкладок в тестах InventoryTabs

## Testing
- `npm test`
- `npm run cy:run` *(failed: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b0c3b408324bb36a57b56e0947e