### PR TITLE
Fix account modal test suite

### DIFF
--- a/src/components/__tests__/AccountModal.test.jsx
+++ b/src/components/__tests__/AccountModal.test.jsx
@@ -1,44 +1,5 @@
 /* eslint-env jest */
 
-import { describe, test, expect, jest } from '@jest/globals'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import AccountModal from '../AccountModal'
-
-const mockUpdateProfile = jest.fn()
-
-jest.mock('../../hooks/useAccount', () => ({
-  useAccount: () => ({
-    updateProfile: mockUpdateProfile,
-  }),
-}))
-
-describe('AccountModal', () => {
-  test('изменение никнейма и закрытие модалки', async () => {
-    const user = { user_metadata: { username: 'старый' } }
-    const onClose = jest.fn()
-    const onUpdated = jest.fn()
-    const updatedUser = { id: 1, user_metadata: { username: 'новый' } }
-
-    mockUpdateProfile.mockResolvedValue({
-      data: { user: updatedUser },
-      error: null,
-    })
-
-    render(<AccountModal user={user} onClose={onClose} onUpdated={onUpdated} />)
-
-    const input = screen.getByLabelText('Никнейм')
-    fireEvent.change(input, { target: { value: 'новый' } })
-    expect(input).toHaveValue('новый')
-
-    fireEvent.click(screen.getByText('Сохранить'))
-
-    await waitFor(() =>
-      expect(mockUpdateProfile).toHaveBeenCalledWith({ username: 'новый' }),
-    )
-    await waitFor(() => expect(onUpdated).toHaveBeenCalledWith(updatedUser))
-    await waitFor(() => expect(onClose).toHaveBeenCalled())
-
-
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -83,6 +44,5 @@ describe('AccountModal', () => {
     expect(mockUpdate).toHaveBeenCalledWith({ username: 'newname' })
     expect(onUpdated).toHaveBeenCalledWith(user)
     expect(onClose).toHaveBeenCalled()
-
   })
 })


### PR DESCRIPTION
## Summary
- clean up AccountModal tests

## Testing
- `npm test src/components/__tests__/AccountModal.test.jsx` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4a191608324b58154887cc32d98