### PR TITLE
fix account modal markup

### DIFF
--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -40,18 +40,11 @@ export default function AccountModal({ user, onClose, onUpdated }) {
           <DialogTitle>Редактирование аккаунта</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-
-          <div>
-            <Label htmlFor="username">Никнейм</Label>
-            <Input
-              id="username"
-              type="text"
-
           <div className="grid gap-2">
             <Label htmlFor="username">Никнейм</Label>
             <Input
               id="username"
-
+              type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               autoFocus
@@ -60,11 +53,7 @@ export default function AccountModal({ user, onClose, onUpdated }) {
         </div>
         <DialogFooter>
           <Button onClick={save} disabled={saving}>
-
             {saving ? 'Сохранение...' : 'Сохранить'}
-
-            Сохранить
-
           </Button>
           <Button variant="ghost" onClick={onClose} disabled={saving}>
             Отмена


### PR DESCRIPTION
## Summary
- tidy account modal grid and input structure
- remove duplicate "Сохранить" text in button

## Testing
- `npm test` *(fails: TestingLibraryElementError, SyntaxError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4a0b6008324aa3b96d74a69775f