### PR TITLE
Refactor tasks tab modals to use Dialog

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -23,7 +23,9 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
       ({
         запланировано: 'badge-info',
         'в процессе': 'badge-warning',
+        'в работе': 'badge-warning',
         завершено: 'badge-success',
+        отменено: 'badge-error',
       })[item.status] || 'badge',
     [item.status],
   )
@@ -84,6 +86,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
               variant="ghost"
               className="w-full xs:w-auto"
               title="Редактировать"
+              aria-label="Редактировать задачу"
               onClick={handleEdit}
             >
               <PencilIcon className="w-4 h-4" />
@@ -93,6 +96,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
               variant="ghost"
               className="w-full xs:w-auto"
               title="Удалить"
+              aria-label="Удалить задачу"
               onClick={handleDelete}
             >
               <TrashIcon className="w-4 h-4" />

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -15,36 +15,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-
-const PAGE_SIZE = 20
-
-function TasksTab({ selected }) {
-
 import { Button } from '@/components/ui/button'
-
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
-} from './ui/dialog'
-
-const PAGE_SIZE = 20
-
-function TasksTab({ selected }) {
-
-import ConfirmModal from './ConfirmModal'
-
-const PAGE_SIZE = 20
-
-
-function TasksTab({ selected }) {
+} from '@/components/ui/dialog'
 
 function TasksTab({ selected, registerAddHandler }) {
-
-
-
   const [tasks, setTasks] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -52,7 +32,7 @@ function TasksTab({ selected, registerAddHandler }) {
     title: '',
     assignee: '',
     due_date: '',
-    status: 'pending',
+    status: 'запланировано',
     notes: '',
   })
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false)
@@ -90,7 +70,7 @@ function TasksTab({ selected, registerAddHandler }) {
       title: '',
       assignee: '',
       due_date: '',
-      status: 'pending',
+      status: 'запланировано',
       notes: '',
     })
     setEditingTask(null)
@@ -119,17 +99,25 @@ function TasksTab({ selected, registerAddHandler }) {
     async (e) => {
       e.preventDefault()
       try {
+        const payload = { ...taskForm, object_id: selected?.id }
         if (editingTask) {
-          await updateTask(editingTask.id, taskForm)
+          await updateTask(editingTask.id, payload)
         } else {
-          await createTask(taskForm)
+          await createTask(payload)
         }
         closeTaskModal()
       } catch (error) {
         console.error('Error saving task:', error)
       }
     },
-    [taskForm, editingTask, createTask, updateTask, closeTaskModal],
+    [
+      taskForm,
+      editingTask,
+      createTask,
+      updateTask,
+      selected?.id,
+      closeTaskModal,
+    ],
   )
 
   const handleEditTask = useCallback((task) => {
@@ -137,7 +125,7 @@ function TasksTab({ selected, registerAddHandler }) {
       title: task.title || '',
       assignee: task.assignee || '',
       due_date: task.due_date || '',
-      status: task.status || 'pending',
+      status: task.status || 'запланировано',
       notes: task.notes || '',
     })
     setEditingTask(task)
@@ -199,46 +187,32 @@ function TasksTab({ selected, registerAddHandler }) {
         <h2 className="text-xl font-bold text-gray-800">
           Задачи для {selected.name}
         </h2>
-        <div className="flex gap-2">
-
-
-
-          <Button size="sm" variant="outline" onClick={openImportModal}>
+        <div className="space-x-2">
+          <Button onClick={openTaskModal}>Добавить задачу</Button>
+          <Button variant="outline" onClick={openImportModal}>
             Импорт
-          </Button>
-          <Button size="sm" onClick={openTaskModal}>
-
-
-          <button className="btn btn-sm btn-outline" onClick={openImportModal}>
-            Импорт
-          </button>
-          <button className="btn btn-sm btn-primary" onClick={openTaskModal}>
-
-            + Добавить
           </Button>
         </div>
       </div>
 
       {tasks.length === 0 ? (
-        <div className="text-gray-500 text-center py-8">
-          Нет данных. Нажмите «Добавить».
+        <div className="text-center text-gray-500">
+          Нет задач для этого объекта.
         </div>
       ) : (
-        <div className="grid gap-4">
+        <div className="space-y-4">
           {tasks.map((task) => (
             <TaskCard
               key={task.id}
               item={task}
-              onEdit={handleEditTask}
-              onDelete={(id) => setTaskDeleteId(id)}
-              onView={setViewingTask}
+              onEdit={() => handleEditTask(task)}
+              onDelete={() => setTaskDeleteId(task.id)}
+              onView={() => setViewingTask(task)}
             />
           ))}
         </div>
       )}
 
-
-      {/* Task Modal */}
       <Dialog
         open={isTaskModalOpen}
         onOpenChange={(open) => {
@@ -246,25 +220,16 @@ function TasksTab({ selected, registerAddHandler }) {
         }}
       >
         <DialogContent>
-          <button
-            className="btn btn-circle absolute right-2 top-2 xs:btn-md md:btn-sm"
-            onClick={closeTaskModal}
-          >
-            ✕
-          </button>
           <DialogHeader>
             <DialogTitle>
-              {editingTask ? 'Редактировать задачу' : 'Добавить задачу'}
+              {editingTask ? 'Редактировать задачу' : 'Новая задача'}
             </DialogTitle>
           </DialogHeader>
           <form onSubmit={handleTaskSubmit} className="space-y-4">
             <div>
-              <label className="label">
-                <span className="label-text">Название *</span>
-              </label>
-              <input
-                type="text"
-                className="input input-bordered w-full"
+              <Label htmlFor="task-title">Название</Label>
+              <Input
+                id="task-title"
                 value={taskForm.title}
                 onChange={(e) =>
                   setTaskForm({ ...taskForm, title: e.target.value })
@@ -273,12 +238,9 @@ function TasksTab({ selected, registerAddHandler }) {
               />
             </div>
             <div>
-              <label className="label">
-                <span className="label-text">Исполнитель</span>
-              </label>
-              <input
-                type="text"
-                className="input input-bordered w-full"
+              <Label htmlFor="task-assignee">Исполнитель</Label>
+              <Input
+                id="task-assignee"
                 value={taskForm.assignee}
                 onChange={(e) =>
                   setTaskForm({ ...taskForm, assignee: e.target.value })
@@ -286,12 +248,10 @@ function TasksTab({ selected, registerAddHandler }) {
               />
             </div>
             <div>
-              <label className="label">
-                <span className="label-text">Дата выполнения</span>
-              </label>
-              <input
+              <Label htmlFor="task-due-date">Дата выполнения</Label>
+              <Input
+                id="task-due-date"
                 type="date"
-                className="input input-bordered w-full"
                 value={taskForm.due_date}
                 onChange={(e) =>
                   setTaskForm({ ...taskForm, due_date: e.target.value })
@@ -299,217 +259,45 @@ function TasksTab({ selected, registerAddHandler }) {
               />
             </div>
             <div>
-              <label className="label">
-                <span className="label-text">Статус</span>
-              </label>
-              <select
-                className="select select-bordered w-full"
+              <Label>Статус</Label>
+              <Select
                 value={taskForm.status}
-                onChange={(e) =>
-                  setTaskForm({ ...taskForm, status: e.target.value })
+                onValueChange={(value) =>
+                  setTaskForm({ ...taskForm, status: value })
                 }
               >
-                <option value="pending">В ожидании</option>
-                <option value="in_progress">В работе</option>
-                <option value="completed">Выполнено</option>
-                <option value="cancelled">Отменено</option>
-              </select>
+                <SelectTrigger className="w-full h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="запланировано">В ожидании</SelectItem>
+                  <SelectItem value="в работе">В работе</SelectItem>
+                  <SelectItem value="завершено">Выполнено</SelectItem>
+                  <SelectItem value="отменено">Отменено</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div>
-              <label className="label">
-                <span className="label-text">Заметки</span>
-              </label>
-              <textarea
-                className="textarea textarea-bordered w-full"
-                rows="3"
+              <Label>Заметки</Label>
+              <Textarea
+                rows={3}
                 value={taskForm.notes}
                 onChange={(e) =>
                   setTaskForm({ ...taskForm, notes: e.target.value })
                 }
-              ></textarea>
+              />
             </div>
             <DialogFooter>
-              <button type="submit" className="btn btn-primary">
+              <Button type="submit">
                 {editingTask ? 'Сохранить' : 'Добавить'}
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                onClick={closeTaskModal}
-              >
+              </Button>
+              <Button type="button" variant="ghost" onClick={closeTaskModal}>
                 Отмена
-              </button>
+              </Button>
             </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
-
-      {/* Add Task Modal */}
-      {isTaskModalOpen && (
-        <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="modal-box relative w-full max-w-md p-4 max-h-screen overflow-y-auto animate-fade-in">
-            <Button
-              size="icon"
-              className="absolute right-2 top-2"
-              onClick={closeTaskModal}
-            >
-              ✕
-            </Button>
-            <h3 className="font-bold text-lg mb-4">
-              {editingTask ? 'Редактировать задачу' : 'Новая задача'}
-            </h3>
-            <form onSubmit={handleTaskSubmit} className="space-y-4">
-              <div>
-
-                <Label className="label">
-                  <span className="label-text">Название *</span>
-                </Label>
-                <Input
-
-                <label className="label">
-                  <span className="label-text">Название</span>
-                </label>
-                <input
-
-                  type="text"
-                  className="input input-bordered w-full"
-                  value={taskForm.title}
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, title: e.target.value })
-                  }
-                  required
-                />
-              </div>
-              <div>
-                <Label className="label">
-                  <span className="label-text">Исполнитель</span>
-                </Label>
-                <Input
-                  type="text"
-                  className="input input-bordered w-full"
-                  value={taskForm.assignee}
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, assignee: e.target.value })
-                  }
-                />
-              </div>
-              <div>
-                <Label className="label">
-                  <span className="label-text">Дата выполнения</span>
-                </Label>
-                <Input
-                  type="date"
-                  className="input input-bordered w-full"
-                  value={taskForm.due_date}
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, due_date: e.target.value })
-                  }
-                />
-              </div>
-              <div>
-                <Label className="label">
-                  <span className="label-text">Статус</span>
-                </Label>
-                <Select
-                  value={taskForm.status}
-
-                  onValueChange={(value) =>
-                    setTaskForm({ ...taskForm, status: value })
-                  }
-                >
-                  <SelectTrigger className="w-full h-9">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="pending">В ожидании</SelectItem>
-                    <SelectItem value="in_progress">В работе</SelectItem>
-                    <SelectItem value="completed">Выполнено</SelectItem>
-                    <SelectItem value="cancelled">Отменено</SelectItem>
-                  </SelectContent>
-                </Select>
-
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, status: e.target.value })
-                  }
-                >
-                  <option value="pending">В ожидании</option>
-                  <option value="in_progress">В процессе</option>
-                  <option value="completed">Завершено</option>
-                </select>
-
-              </div>
-              <div>
-                <Label className="label">
-                  <span className="label-text">Заметки</span>
-                </Label>
-                <Textarea
-                  className="textarea textarea-bordered w-full"
-                  rows={3}
-                  value={taskForm.notes}
-
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, notes: e.target.value })
-                  }
-                />
-
-
-                  onChange={(e) =>
-                    setTaskForm({ ...taskForm, notes: e.target.value })
-                  }
-                ></textarea>
-
-                  onChange={(e) => setTaskForm({ ...taskForm, notes: e.target.value })}
-                />
-
-
-              </div>
-              <div className="modal-action flex space-x-2">
-                <Button type="submit">
-                  {editingTask ? 'Сохранить' : 'Добавить'}
-
-                </Button>
-                <Button type="button" variant="ghost" onClick={closeTaskModal}>
-
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  onClick={closeTaskModal}
-                >
-
-                  Отмена
-                </Button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
-
-
-      {/* View Task Modal */}
-
-      {viewingTask && (
-        <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="modal-box relative w-full max-w-md p-4 max-h-screen overflow-y-auto animate-fade-in">
-            <Button
-              size="icon"
-              className="absolute right-2 top-2"
-              onClick={() => setViewingTask(null)}
-            >
-              ✕
-            </Button>
-            <h3 className="font-bold text-lg mb-4">{viewingTask.title}</h3>
-            <div className="space-y-2">
-              {viewingTask.assignee && (
-                <p>
-                  <strong>Исполнитель:</strong> {viewingTask.assignee}
-                </p>
-              )}
-              {viewingTask.due_date && (
-                <p>
-                  <strong>Дата:</strong> {formatDate(viewingTask.due_date)}
-                </p>
-              )}
 
       <Dialog
         open={!!viewingTask}
@@ -518,18 +306,11 @@ function TasksTab({ selected, registerAddHandler }) {
         }}
       >
         <DialogContent>
-          <button
-            className="btn btn-circle absolute right-2 top-2 xs:btn-md md:btn-sm"
-            onClick={() => setViewingTask(null)}
-          >
-            ✕
-          </button>
           <DialogHeader>
             <DialogTitle>{viewingTask?.title}</DialogTitle>
           </DialogHeader>
           <div className="space-y-2">
             {viewingTask?.assignee && (
-
               <p>
                 <strong>Исполнитель:</strong> {viewingTask.assignee}
               </p>
@@ -551,41 +332,12 @@ function TasksTab({ selected, registerAddHandler }) {
         </DialogContent>
       </Dialog>
 
-      {/* Confirm Delete Modal */}
       <ConfirmModal
         open={!!taskDeleteId}
         title="Удалить задачу?"
         onConfirm={confirmDeleteTask}
         onCancel={() => setTaskDeleteId(null)}
       />
-
-      {/* Import Modal */}
-
-      {isImportModalOpen && (
-        <div className="modal modal-open fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="modal-box relative w-full max-w-md p-4 max-h-screen overflow-y-auto animate-fade-in">
-            <Button
-              size="icon"
-              className="absolute right-2 top-2"
-              onClick={closeImportModal}
-            >
-              ✕
-            </Button>
-            <h3 className="font-bold text-lg mb-4">Импорт задач</h3>
-            <Input
-              type="file"
-              className="file-input file-input-bordered w-full"
-              onChange={(e) => setImportFile(e.target.files[0])}
-            />
-            <div className="modal-action flex space-x-2">
-              <Button onClick={handleImport}>Загрузить</Button>
-              <Button variant="ghost" onClick={closeImportModal}>
-                Отмена
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
 
       <Dialog
         open={isImportModalOpen}
@@ -594,47 +346,29 @@ function TasksTab({ selected, registerAddHandler }) {
         }}
       >
         <DialogContent>
-          <button
-            className="btn btn-circle absolute right-2 top-2 xs:btn-md md:btn-sm"
-            onClick={closeImportModal}
-          >
-            ✕
-          </button>
           <DialogHeader>
             <DialogTitle>Импорт задач</DialogTitle>
           </DialogHeader>
-          <input
+          <Input
             type="file"
             className="file-input file-input-bordered w-full"
             onChange={(e) => setImportFile(e.target.files[0])}
           />
           <DialogFooter>
-            <button className="btn btn-primary" onClick={handleImport}>
-              Загрузить
-            </button>
-            <button className="btn btn-ghost" onClick={closeImportModal}>
+            <Button onClick={handleImport}>Загрузить</Button>
+            <Button variant="ghost" onClick={closeImportModal}>
               Отмена
-            </button>
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
     </div>
   )
 }
 
 TasksTab.propTypes = {
   selected: PropTypes.object,
-
-
-
-
-  user: PropTypes.object,
-
   registerAddHandler: PropTypes.func,
-
-
-
 }
 
 export default TasksTab

--- a/tests/TasksTab.test.jsx
+++ b/tests/TasksTab.test.jsx
@@ -91,13 +91,10 @@ describe('TasksTab', () => {
     await act(async () => {
       fireEvent.change(titleInput, { target: { value: 'Новая задача' } })
       fireEvent.change(assigneeInput, { target: { value: 'Иван Петров' } })
-      fireEvent.change(dueDateInput, { target: { value: '2024-12-31' } })
+      fireEvent.change(dueDateInput, { target: { value: '2024-05-10' } })
     })
 
-    fireEvent.click(screen.getByText('📅'))
-    const dateInput = document.querySelector('input[type="date"]')
-    fireEvent.change(dateInput, { target: { value: '2024-05-10' } })
-    fireEvent.click(screen.getByText('Сохранить'))
+    fireEvent.click(screen.getByText('Добавить'))
 
     await waitFor(() => {
       expect(mockCreateTask).toHaveBeenCalledWith({
@@ -138,7 +135,9 @@ describe('TasksTab', () => {
 
     await act(async () => {
       fireEvent.change(titleInput, { target: { value: 'Обновленная задача' } })
-      fireEvent.change(assigneeInput, { target: { value: 'Новый исполнитель' } })
+      fireEvent.change(assigneeInput, {
+        target: { value: 'Новый исполнитель' },
+      })
     })
 
     fireEvent.click(screen.getByText('Сохранить'))


### PR DESCRIPTION
## Summary
- simplify TasksTab by using only Dialog-based modals
- make task form accessible and adjust TaskCard labels
- align tests with the new modal implementation

## Testing
- `npm test` *(fails: 6 failed, 19 passed)*
- `npx jest tests/TasksTab.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68aca8e41adc832493bf6712013656cf