### PR TITLE
test: mock Supabase in tests

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,3 +3,24 @@
 import '@testing-library/jest-dom'
 
 process.env.VITE_API_BASE_URL = 'http://localhost'
+process.env.VITE_SUPABASE_URL = 'http://localhost'
+process.env.VITE_SUPABASE_ANON_KEY = 'test-key'
+
+jest.mock('@supabase/supabase-js', () => {
+  return {
+    createClient: () => {
+      const proxy = new Proxy(() => {}, {
+        get(target, prop) {
+          if (prop === 'then') {
+            return (resolve) => resolve({ data: null, error: null })
+          }
+          return proxy
+        },
+        apply() {
+          return proxy
+        },
+      })
+      return proxy
+    },
+  }
+})


### PR DESCRIPTION
## Summary
- set Supabase env variables for tests
- globally mock Supabase client to avoid real requests

## Testing
- `npm test` (fails: Jest encountered an unexpected token etc., but no Supabase initialization errors)

------
https://chatgpt.com/codex/tasks/task_e_68acb06f90d88324a071e90984c29eef