### PR TITLE
refactor: use logger for session errors

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -30,7 +30,7 @@ export function AuthProvider({ children }) {
       setIsLoading(true)
       const { user: currentUser, error: sessionError } = await fetchSession()
       if (sessionError) {
-        console.error('Ошибка получения сессии:', sessionError)
+        logger.error('Ошибка получения сессии:', sessionError)
         toast.error('Ошибка получения сессии: ' + sessionError.message)
         setUser(null)
         setRole(null)


### PR DESCRIPTION
## Summary
- replace console.error with logger.error in AuthContext to ensure consistent logging

## Testing
- `npm test` *(fails: Test Suites: 6 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3f421488324aec8d8128a3d586f