### PR TITLE
feat: cancel Supabase queries

### DIFF
--- a/src/utils/useSupabaseQuery.js
+++ b/src/utils/useSupabaseQuery.js
@@ -8,12 +8,13 @@ export function useSupabaseQuery(queryBuilder, deps = []) {
 
   useEffect(() => {
     let active = true
+    const controller = new AbortController()
     setIsLoading(true)
     setIsError(null)
 
     async function run() {
       try {
-        const { data, error } = await queryBuilder(supabase)
+        const { data, error } = await queryBuilder(supabase, controller.signal)
         if (!active) return
         if (error) {
           setIsError(error)
@@ -22,6 +23,7 @@ export function useSupabaseQuery(queryBuilder, deps = []) {
           setData(data)
         }
       } catch (err) {
+        if (err?.name === 'AbortError') return
         if (active) {
           setIsError(err)
           setData(null)
@@ -34,6 +36,7 @@ export function useSupabaseQuery(queryBuilder, deps = []) {
     run()
     return () => {
       active = false
+      controller.abort()
     }
   }, deps)
 

--- a/tests/useSupabaseQuery.test.js
+++ b/tests/useSupabaseQuery.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { renderHook, act } from '@testing-library/react'
+import { useSupabaseQuery } from '../src/utils/useSupabaseQuery.js'
+
+describe('useSupabaseQuery', () => {
+  it('не выставляет ошибку при отмене запроса', async () => {
+    const queryBuilder = jest.fn(
+      (_, signal) =>
+        new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError')),
+          )
+        }),
+    )
+
+    const { result, unmount } = renderHook(() => useSupabaseQuery(queryBuilder))
+    const signal = queryBuilder.mock.calls[0][1]
+    expect(signal.aborted).toBe(false)
+
+    await act(async () => {
+      unmount()
+      await Promise.resolve()
+    })
+
+    expect(signal.aborted).toBe(true)
+    expect(result.current.isError).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- cancel Supabase queries using AbortController
- test query cancellation handling

## Testing
- `npm test` *(fails: SyntaxError in ChatTab.jsx and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3f43090832486e4fbf90db454ab