### PR TITLE
Overlay spinner covers entire screen and keep loading state handling

### DIFF
--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -9,7 +9,12 @@ export default function PrivateRoute({ children }) {
   if (isLoading) {
     return <Spinner />
   }
-  return user ? children : <Navigate to="/auth" replace />
+
+  if (!user) {
+    return <Navigate to="/auth" replace />
+  }
+
+  return children
 }
 
 PrivateRoute.propTypes = {

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -1,24 +1,26 @@
 export default function Spinner() {
   return (
-    <div className="flex justify-center p-4" data-testid="spinner">
-      <svg
-        className="animate-spin h-5 w-5 text-base-content/70 transition-colors"
-        viewBox="0 0 24 24"
-      >
-        <circle
-          className="opacity-25"
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="4"
-        ></circle>
-        <path
-          className="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8v8H4z"
-        ></path>
-      </svg>
+    <div className="fixed inset-0 flex items-center justify-center">
+      <div className="flex justify-center p-4" data-testid="spinner">
+        <svg
+          className="animate-spin h-5 w-5 text-primary transition-colors"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          ></circle>
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v8H4z"
+          ></path>
+        </svg>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expand Spinner into a full-screen overlay using primary color for contrast
- keep explicit loading indicator in PrivateRoute when auth state is pending

## Testing
- `npm test` *(fails: 6 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68acbbfcadb88324b09e079fa62da406