### PR TITLE
Handle missing Supabase config in auth context and add PrivateRoute tests

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -18,7 +18,10 @@ export function AuthProvider({ children }) {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    if (!isSupabaseConfigured) return
+    if (!isSupabaseConfigured) {
+      setIsLoading(false)
+      return
+    }
     if (!isApiConfigured) {
       logger.error(
         'Не задана переменная окружения VITE_API_BASE_URL. Авторизация через API недоступна.',

--- a/tests/PrivateRoute.test.jsx
+++ b/tests/PrivateRoute.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PrivateRoute from '@/components/PrivateRoute.jsx'
+import { useAuth } from '@/hooks/useAuth.js'
+
+jest.mock('@/hooks/useAuth.js', () => ({
+  useAuth: jest.fn(),
+}))
+
+describe('PrivateRoute', () => {
+  it('показывает индикатор загрузки во время ожидания', () => {
+    useAuth.mockReturnValue({ user: null, isLoading: true })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <PrivateRoute>
+                <div>Секрет</div>
+              </PrivateRoute>
+            }
+          />
+          <Route path="/auth" element={<div>Вход</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument()
+  })
+
+  it('перенаправляет на страницу входа при отсутствии пользователя', () => {
+    useAuth.mockReturnValue({ user: null, isLoading: false })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <PrivateRoute>
+                <div>Секрет</div>
+              </PrivateRoute>
+            }
+          />
+          <Route path="/auth" element={<div>Вход</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Вход')).toBeInTheDocument()
+  })
+
+  it('отображает содержимое для авторизованного пользователя', () => {
+    useAuth.mockReturnValue({ user: { id: '1' }, isLoading: false })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <PrivateRoute>
+                <div>Секрет</div>
+              </PrivateRoute>
+            }
+          />
+          <Route path="/auth" element={<div>Вход</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Секрет')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Ensure AuthContext stops loading when Supabase is not configured
- Add tests covering PrivateRoute loading and redirect cases

## Testing
- `npm test` *(fails: 6 failed, 22 passed, 28 total)*
- `npx jest tests/PrivateRoute.test.jsx tests/AuthContext.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68acbbfcfea883249d99e3dd441ea80a