### PR TITLE
fix: memoize object list fetch

### DIFF
--- a/src/hooks/useObjectList.js
+++ b/src/hooks/useObjectList.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
 import { toast } from 'react-hot-toast'
@@ -14,11 +14,7 @@ export function useObjectList() {
   const [fetchError, setFetchError] = useState(null)
   const [isEmpty, setIsEmpty] = useState(false)
 
-  useEffect(() => {
-    fetchObjects()
-  }, [])
-
-  async function fetchObjects() {
+  const fetchObjects = useCallback(async () => {
     let data
     try {
       const { data: fetchedData, error } = await supabase
@@ -78,7 +74,11 @@ export function useObjectList() {
     } else if (!selected && data.length) {
       setSelected(data[0])
     }
-  }
+  }, [navigate, selected])
+
+  useEffect(() => {
+    fetchObjects()
+  }, [fetchObjects])
 
   async function saveObject(name, editingObject) {
     if (!name.trim()) return false


### PR DESCRIPTION
## Summary
- memoize object list fetch to satisfy hook deps
- trigger fetch effect on fetchObjects change

## Testing
- `npm test` (fails: 7 failed, 68 passed)
- `npx eslint src/hooks/useObjectList.js`


------
https://chatgpt.com/codex/tasks/task_e_68adadadc72483249079271915227b32