### PR TITLE
Добавлен queryBuilder в зависимости useSupabaseQuery

### DIFF
--- a/src/utils/useSupabaseQuery.js
+++ b/src/utils/useSupabaseQuery.js
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../supabaseClient'
 
+/**
+ * Хук для выполнения запроса к Supabase.
+ * @param {Function} queryBuilder функция формирования запроса. Добавлена в массив зависимостей.
+ * @param {Array} deps дополнительные зависимости, при изменении которых запрос должен переисполняться.
+ * Передавайте дополнительные зависимости явно, чтобы избежать устаревших данных.
+ */
 export function useSupabaseQuery(queryBuilder, deps = []) {
   const [data, setData] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(null)
 
+  // queryBuilder присутствует в массиве зависимостей; указывайте дополнительные deps через параметр
   useEffect(() => {
     let active = true
     const controller = new AbortController()
@@ -38,7 +45,8 @@ export function useSupabaseQuery(queryBuilder, deps = []) {
       active = false
       controller.abort()
     }
-  }, deps)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryBuilder, ...deps])
 
   return { data, isLoading, isError }
 }


### PR DESCRIPTION
## Summary
- включен `queryBuilder` в массив зависимостей `useSupabaseQuery`
- добавлена документация о явной передаче дополнительных зависимостей

## Testing
- `npx eslint src/utils/useSupabaseQuery.js`
- `npm test` *(failed: Test Suites: 6 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68adadba5ea48324a7ad6c3ef14117e9