### PR TITLE
feat: добавить резервные переменные окружения

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,6 +1,8 @@
+/* global process */
 import logger from './utils/logger'
 
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+const apiBaseUrl =
+  import.meta.env?.VITE_API_BASE_URL || process.env.VITE_API_BASE_URL
 
 export const isApiConfigured = Boolean(apiBaseUrl)
 

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,8 +1,11 @@
+/* global process */
 import { createClient } from '@supabase/supabase-js'
 import logger from './utils/logger'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl =
+  import.meta.env?.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const supabaseKey =
+  import.meta.env?.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY
 
 export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseKey)
 


### PR DESCRIPTION
## Summary
- добавить резервное чтение VITE_API_BASE_URL из process.env
- использовать process.env для fallback переменных Supabase

## Testing
- `npx eslint src/apiConfig.js src/supabaseClient.js && echo 'LINT_OK'`
- `npm run lint` (fail: Insert `⏎` prettier/prettier, Replace `.from('tasks')...`)
- `npm test` (fail: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')


------
https://chatgpt.com/codex/tasks/task_e_68adadbec52c8324982b55bd057a4014