### PR TITLE
Fix shadcn ui components

### DIFF
--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -34,7 +34,7 @@ export const DialogContent = React.forwardRef(function DialogContent(
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-base-100 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,9 +1,19 @@
 import React from 'react'
-import { cn } from '../../utils/cn'
+import { cn } from '@/lib/utils'
 
 export const Input = React.forwardRef(function Input(
   { className, ...props },
   ref,
 ) {
-  return <input ref={ref} className={cn(className)} {...props} />
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
 })
+Input.displayName = 'Input'

--- a/src/components/ui/textarea.jsx
+++ b/src/components/ui/textarea.jsx
@@ -1,9 +1,19 @@
 import React from 'react'
-import { cn } from '../../utils/cn'
+import { cn } from '@/lib/utils'
 
 export const Textarea = React.forwardRef(function Textarea(
   { className, ...props },
   ref,
 ) {
-  return <textarea ref={ref} className={cn(className)} {...props} />
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    ></textarea>
+  )
 })
+Textarea.displayName = 'Textarea'


### PR DESCRIPTION
## Summary
- fix Input: add tailwind styles, correct import and closing tag
- fix Textarea: add tailwind styles, correct import and closing tag
- fix Dialog: remove daisyUI classes and use shadcn background

## Testing
- `npm test` *(fails: TypeError: onOpenChange is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68adb42c08b88324a38ae4d5ce362996