### PR TITLE
Configure path aliases for shadcn/ui

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      '@': path.resolve(__dirname, './src'),
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- add jsconfig with base url and `@/*` path mapping
- update Vite alias to resolve `@` to `src`

## Testing
- `npm test` *(fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts'; 6 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68adb4a6967c8324be61f22270f5b956