### PR TITLE
feat: переключение темы через .dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="ru" data-theme="light" class="transition-colors duration-300">
+<html lang="ru" class="transition-colors duration-300">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inventory App</title>
   </head>
-  <body class="bg-base-200 w-full min-h-screen transition-colors duration-300">
+  <body class="w-full min-h-screen bg-background text-foreground transition-colors duration-300">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -15,7 +15,13 @@ export default function ThemeToggle() {
 
   // Устанавливаем выбранную тему при монтировании и при изменении
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme)
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(THEME_KEY, theme)
     }


### PR DESCRIPTION
## Summary
- remove legacy data-theme attribute and body base color
- toggle theme by adding/removing `.dark` class

## Testing
- `npm test` (fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')

------
https://chatgpt.com/codex/tasks/task_e_68adb51737888324841b2940ccef7914