### PR TITLE
refactor: migrate button to shadcn

### DIFF
--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,25 +1,28 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { cva } from 'class-variance-authority'
-import { cn } from '../../utils/cn'
+import { Slot } from '@radix-ui/react-slot'
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-content hover:bg-primary/90',
-        secondary: 'bg-secondary text-secondary-content hover:bg-secondary/90',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input hover:bg-accent hover:text-accent-foreground',
-        link: 'underline-offset-4 hover:underline text-primary',
-        destructive: 'bg-error text-error-content hover:bg-error/90',
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-10 px-4 py-2',
-        sm: 'h-9 px-3',
-        lg: 'h-11 px-8',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',
       },
     },
@@ -30,25 +33,19 @@ const buttonVariants = cva(
   },
 )
 
-const Button = React.forwardRef(
-  ({ className, variant, size, asChild = false, children, ...props }, ref) => {
-    const classes = cn(buttonVariants({ variant, size }), className)
-
-    if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children, {
-        className: cn(classes, children.props.className),
-        ref,
-        ...props,
-      })
-    }
-
-    return (
-      <button className={classes} ref={ref} {...props}>
-        {children}
-      </button>
-    )
-  },
-)
+const Button = React.forwardRef(function Button(
+  { className, variant, size, asChild = false, ...props },
+  ref,
+) {
+  const Component = asChild ? Slot : 'button'
+  return (
+    <Component
+      className={cn(buttonVariants({ variant, size }), className)}
+      ref={ref}
+      {...props}
+    />
+  )
+})
 
 Button.displayName = 'Button'
 
@@ -57,10 +54,10 @@ Button.propTypes = {
   variant: PropTypes.oneOf([
     'default',
     'secondary',
-    'ghost',
-    'outline',
-    'link',
     'destructive',
+    'outline',
+    'ghost',
+    'link',
   ]),
   size: PropTypes.oneOf(['default', 'sm', 'lg', 'icon']),
   asChild: PropTypes.bool,


### PR DESCRIPTION
## Summary
- refactor button to shadcn styles
- use named forwardRef with Slot
- update prop types and display name

## Testing
- `npm test` *(fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts' from 'supabase/functions/export/index.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68adb591a2288324b87e0329690ed2f8