### PR TITLE
refactor: name card component refs

### DIFF
--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,37 +1,65 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import { cn } from '../../utils/cn'
+import { cn } from '@/lib/utils'
 
-const Card = forwardRef(({ className, children, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
-      className,
-    )}
-    {...props}
-  >
-    {children}
-  </div>
-))
+const Card = forwardRef(function Card({ className, children, ...props }, ref) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded-lg border bg-card text-card-foreground shadow-sm',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+})
 
-const CardHeader = forwardRef(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={cn('p-4', className)} {...props}>
-    {children}
-  </div>
-))
+const CardHeader = forwardRef(function CardHeader(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn('flex flex-col space-y-1.5 p-6', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+})
 
-const CardTitle = forwardRef(({ className, children, ...props }, ref) => (
-  <h3 ref={ref} className={cn('text-lg font-semibold', className)} {...props}>
-    {children}
-  </h3>
-))
+const CardTitle = forwardRef(function CardTitle(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <h3
+      ref={ref}
+      className={cn(
+        'text-2xl font-semibold leading-none tracking-tight',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </h3>
+  )
+})
 
-const CardContent = forwardRef(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={cn('p-4', className)} {...props}>
-    {children}
-  </div>
-))
+const CardContent = forwardRef(function CardContent(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props}>
+      {children}
+    </div>
+  )
+})
 
 Card.displayName = 'Card'
 CardHeader.displayName = 'CardHeader'


### PR DESCRIPTION
## Summary
- refactor card component to use named forwardRef functions
- adjust default card layout classes and import `cn` from alias

## Testing
- `npm test` (fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')
- `npm run lint` (fails: 10 problems)

------
https://chatgpt.com/codex/tasks/task_e_68adb5941dd08324b23170747666a417