### PR TITLE
feat(ui): migrate select component to Radix

### DIFF
--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,47 +1,158 @@
 import React from 'react'
-import { cn } from '../../utils/cn'
+import PropTypes from 'prop-types'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { cn } from '@/lib/utils'
 
-export function Select({ value, onValueChange, children }) {
-  const items = []
-  let triggerProps = {}
-  React.Children.forEach(children, (child) => {
-    if (child.type === SelectTrigger) {
-      triggerProps = child.props || {}
-    }
-    if (child.type === SelectContent) {
-      React.Children.forEach(child.props.children, (item) => {
-        if (item.type === SelectItem) {
-          items.push(item)
-        }
-      })
-    }
-  })
+const Select = SelectPrimitive.Root
+const SelectGroup = SelectPrimitive.Group
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef(function SelectTrigger(
+  { className, children, ...props },
+  ref,
+) {
   return (
-    <select
-      value={value}
-      onChange={(e) => onValueChange && onValueChange(e.target.value)}
-      className={cn(triggerProps.className)}
+    <SelectPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
     >
-      {triggerProps.children &&
-        React.Children.map(triggerProps.children, (child) =>
-          child.type === SelectValue && child.props.placeholder ? (
-            <option value="" disabled>
-              {child.props.placeholder}
-            </option>
-          ) : null,
-        )}
-      {items.map((item, index) => (
-        <option key={index} value={item.props.value}>
-          {item.props.children}
-        </option>
-      ))}
-    </select>
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
   )
+})
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef(function SelectContent(
+  { className, children, position = 'popper', ...props },
+  ref,
+) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn(
+          'relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md animate-in fade-in-80',
+          position === 'popper' && 'translate-y-1',
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectPrimitive.ScrollUpButton className="flex h-6 cursor-default items-center justify-center bg-popover">
+          <ChevronUp className="h-4 w-4" />
+        </SelectPrimitive.ScrollUpButton>
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectPrimitive.ScrollDownButton className="flex h-6 cursor-default items-center justify-center bg-popover">
+          <ChevronDown className="h-4 w-4" />
+        </SelectPrimitive.ScrollDownButton>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+})
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef(function SelectLabel(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <SelectPrimitive.Label
+      ref={ref}
+      className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+      {...props}
+    />
+  )
+})
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef(function SelectItem(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+})
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef(function SelectSeparator(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  )
+})
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+SelectTrigger.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
 }
 
-export const SelectTrigger = ({ children, className }) => <>{children}</> // eslint-disable-line no-unused-vars
-export const SelectContent = ({ children }) => <>{children}</>
-export const SelectItem = ({ value, children }) => (
-  <option value={value}>{children}</option>
-)
-export const SelectValue = ({ placeholder }) => null // eslint-disable-line no-unused-vars
+SelectContent.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  position: PropTypes.oneOf(['item-aligned', 'popper']),
+}
+
+SelectLabel.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+}
+
+SelectItem.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  value: PropTypes.string,
+  disabled: PropTypes.bool,
+}
+
+SelectSeparator.propTypes = {
+  className: PropTypes.string,
+}
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+}


### PR DESCRIPTION
## Summary
- refactor select UI component to use Radix primitives
- add display names and PropTypes

## Testing
- `npm test` *(fails: TypeError: watch is not a function; Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68adb59a8a2c8324a38201a70bf59a89