### PR TITLE
refactor scroll-area to named forwardRef

### DIFF
--- a/src/components/ui/scroll-area.jsx
+++ b/src/components/ui/scroll-area.jsx
@@ -1,12 +1,17 @@
+import React from 'react'
 import PropTypes from 'prop-types'
-import { forwardRef } from 'react'
-import { cn } from '../../utils/cn'
+import { cn } from '@/lib/utils'
 
-const ScrollArea = forwardRef(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={cn(className)} {...props}>
-    {children}
-  </div>
-))
+const ScrollArea = React.forwardRef(function ScrollArea(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <div ref={ref} className={cn(className)} {...props}>
+      {children}
+    </div>
+  )
+})
 
 ScrollArea.displayName = 'ScrollArea'
 


### PR DESCRIPTION
## Summary
- refactor ScrollArea to use named React.forwardRef
- use shared cn utility via alias path

## Testing
- `npm test` (fails: 6 failing test suites)
- `npm run lint` (fails: 10 problems)


------
https://chatgpt.com/codex/tasks/task_e_68adb59ba8a8832495cba3a13ddb4934