### PR TITLE
feat: implement Radix Tabs component

### DIFF
--- a/src/components/ui/tabs.jsx
+++ b/src/components/ui/tabs.jsx
@@ -1,73 +1,91 @@
-import React, { createContext, useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import { cn } from '../../utils/cn'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { cn } from '@/lib/utils'
 
-const TabsContext = createContext()
+const Tabs = React.forwardRef(function Tabs({ className, ...props }, ref) {
+  return <TabsPrimitive.Root ref={ref} className={cn(className)} {...props} />
+})
 
-function Tabs({ value, onValueChange, children, className, ...props }) {
+const TabsList = React.forwardRef(function TabsList(
+  { className, ...props },
+  ref,
+) {
   return (
-    <TabsContext.Provider value={{ value, onValueChange }}>
-      <div className={cn(className)} {...props}>
-        {children}
-      </div>
-    </TabsContext.Provider>
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn(
+        'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
   )
-}
+})
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef(function TabsTrigger(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef(function TabsContent(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
+        'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+Tabs.displayName = TabsPrimitive.Root.displayName
 
 Tabs.propTypes = {
-  value: PropTypes.string.isRequired,
-  onValueChange: PropTypes.func.isRequired,
-  children: PropTypes.node,
+  defaultValue: PropTypes.string,
+  value: PropTypes.string,
+  onValueChange: PropTypes.func,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  dir: PropTypes.oneOf(['ltr', 'rtl']),
   className: PropTypes.string,
-}
-
-function TabsList({ children, className, ...props }) {
-  return (
-    <div className={cn(className)} {...props}>
-      {children}
-    </div>
-  )
+  children: PropTypes.node,
 }
 
 TabsList.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
-}
-
-function TabsTrigger({ value, children, className, ...props }) {
-  const { value: active, onValueChange } = useContext(TabsContext)
-  const activeClass = active === value ? 'tab-active' : ''
-  return (
-    <button
-      className={cn(className, activeClass)}
-      onClick={() => onValueChange(value)}
-      {...props}
-    >
-      {children}
-    </button>
-  )
+  children: PropTypes.node,
 }
 
 TabsTrigger.propTypes = {
   value: PropTypes.string.isRequired,
-  children: PropTypes.node,
   className: PropTypes.string,
-}
-
-function TabsContent({ value, children, className, ...props }) {
-  const { value: active } = useContext(TabsContext)
-  if (active !== value) return null
-  return (
-    <div className={cn(className)} {...props}>
-      {children}
-    </div>
-  )
+  disabled: PropTypes.bool,
+  children: PropTypes.node,
 }
 
 TabsContent.propTypes = {
   value: PropTypes.string.isRequired,
-  children: PropTypes.node,
   className: PropTypes.string,
+  children: PropTypes.node,
 }
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- replace custom tabs with Radix-based implementation using named forwardRef wrappers
- add display names and prop types
- apply utility classes and alias imports

## Testing
- `npm test` (fails: Test Suites: 6 failed, 22 passed)


------
https://chatgpt.com/codex/tasks/task_e_68adb59e622c8324bd696f59fb050f2b