### PR TITLE
refactor(auth): simplify input classes

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -11,7 +11,6 @@ import { Input } from '@/components/ui/input'
 
 import { Button } from '@/components/ui/button'
 
-
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
   const [userError, setUserError] = useState(null)
@@ -111,7 +110,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="email"
-                className="input input-bordered w-full"
+                className="w-full"
                 placeholder="Email"
                 {...register('email')}
               />
@@ -126,7 +125,7 @@ export default function AuthPage() {
               <div>
                 <Input
                   type="text"
-                  className="input input-bordered w-full"
+                  className="w-full"
                   placeholder="Имя пользователя"
                   {...register('username')}
                 />
@@ -141,7 +140,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="password"
-                className="input input-bordered w-full"
+                className="w-full"
                 placeholder="Пароль"
                 {...register('password')}
               />


### PR DESCRIPTION
## Summary
- streamline AuthPage inputs by dropping extra daisyUI classes

## Testing
- `CI=1 npm test` *(fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts' etc.)*
- manual Supabase signup/login *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5c15d9c8324b442c5574cc7cb2a