### PR TITLE
Replace DaisyUI remnants with shadcn/ui components

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="ru" data-theme="light" class="transition-colors duration-300">
+<html lang="ru" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inventory App</title>
   </head>
-  <body class="bg-base-200 w-full min-h-screen transition-colors duration-300">
+  <body class="bg-background w-full min-h-screen">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 export default function Card({ children, className = '', ...props }) {
   return (
     <div
-      className={`rounded-2xl shadow-md p-4 bg-base-100 transition-colors ${className}`}
+      className={`rounded-2xl shadow-md p-4 bg-card text-card-foreground ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ChatCard.jsx
+++ b/src/components/ChatCard.jsx
@@ -15,7 +15,7 @@ function formatDate(dateStr) {
 export default function ChatCard({ message }) {
   return (
     <Card className="animate-fade-in">
-      <div className="text-sm text-base-content/70 mb-1 transition-colors">
+      <div className="text-sm text-muted-foreground mb-1">
         {message.sender}
         {message.created_at && ` • ${formatDate(message.created_at)}`}
       </div>

--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { PaperClipIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import useChat from '../hooks/useChat.js'
 
 function ChatTab({ selected = null, userEmail }) {
@@ -59,32 +62,31 @@ function ChatTab({ selected = null, userEmail }) {
 
   if (!objectId) {
     return (
-      <div className="p-6 text-sm text-base-content/70 transition-colors">
-        Выбери объект
-      </div>
+      <div className="p-6 text-sm text-muted-foreground">Выбери объект</div>
     )
   }
 
   return (
     <div className="flex flex-col h-full">
       <div className="px-3 py-2">
-        <button
+        <Button
           type="button"
-          className="btn btn-ghost"
+          variant="ghost"
+          size="icon"
           aria-label="Поиск"
           onClick={handleSearchToggle}
         >
           <MagnifyingGlassIcon className="w-6 h-6" />
-        </button>
+        </Button>
         <div
           className={`transition-all duration-300 overflow-hidden ${
             isSearchOpen ? 'max-h-12 mt-1' : 'max-h-0'
           }`}
         >
           {isSearchOpen && (
-            <input
+            <Input
               type="text"
-              className="input input-bordered input-sm w-full"
+              className="w-full h-8 rounded-md border border-input bg-background px-2 text-sm"
               placeholder="Поиск сообщений"
               value={searchInput}
               onChange={handleSearchChange}
@@ -95,22 +97,22 @@ function ChatTab({ selected = null, userEmail }) {
       </div>
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto p-4 space-y-3 bg-base-200 rounded-2xl"
+        className="flex-1 overflow-y-auto p-4 space-y-3 bg-muted rounded-2xl"
       >
         {loadError ? (
           <div className="text-center">
             <p className="mb-2 text-error">Не удалось загрузить сообщения</p>
-            <button className="btn btn-sm" onClick={() => loadMore(true)}>
+            <Button size="sm" onClick={() => loadMore(true)}>
               Повторить
-            </button>
+            </Button>
           </div>
         ) : (
           <>
             {hasMore && (
               <div className="text-center">
-                <button className="btn btn-sm" onClick={() => loadMore()}>
+                <Button size="sm" onClick={() => loadMore()}>
                   Загрузить ещё
-                </button>
+                </Button>
               </div>
             )}
             {messages.length === 0 ? (
@@ -137,16 +139,18 @@ function ChatTab({ selected = null, userEmail }) {
                 return (
                   <div
                     key={m.id}
-                    className={`chat ${isOwn ? 'chat-end' : 'chat-start'}`}
+                    className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
                   >
                     {!isOwn && (
-                      <div className="chat-header">{m.sender || 'user'}</div>
+                      <div className="mb-1 text-xs text-muted-foreground">
+                        {m.sender || 'user'}
+                      </div>
                     )}
                     <div
-                      className={`chat-bubble max-w-[80%] sm:max-w-[60%] whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
+                      className={`max-w-[80%] sm:max-w-[60%] whitespace-pre-wrap break-words rounded-2xl shadow-md px-4 py-2 flex flex-col ${
                         isOwn
-                          ? 'bg-primary text-primary-content'
-                          : 'bg-base-100 text-base-content'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-card text-card-foreground'
                       }`}
                     >
                       {m.content && (
@@ -176,17 +180,16 @@ function ChatTab({ selected = null, userEmail }) {
       <div className="p-3 border-t space-y-2">
         {file && filePreview && <AttachmentPreview url={filePreview} />}
         <div className="flex items-center gap-2">
-          <label
-            htmlFor="chat-file-input"
-            className="btn btn-ghost"
-            data-testid="file-label"
-            aria-label="Прикрепить файл"
-            title="Прикрепить файл"
-            role="button"
-            tabIndex={0}
-          >
-            <PaperClipIcon className="w-6 h-6" />
-          </label>
+          <Button variant="ghost" size="icon" asChild>
+            <label
+              htmlFor="chat-file-input"
+              data-testid="file-label"
+              aria-label="Прикрепить файл"
+              title="Прикрепить файл"
+            >
+              <PaperClipIcon className="w-6 h-6" />
+            </label>
+          </Button>
           <input
             id="chat-file-input"
             type="file"
@@ -194,8 +197,8 @@ function ChatTab({ selected = null, userEmail }) {
             ref={fileInputRef}
             onChange={handleFileChange}
           />
-          <textarea
-            className="textarea textarea-bordered w-full min-h-24"
+          <Textarea
+            className="w-full min-h-24 rounded-md border border-input bg-background px-3 py-2 text-sm"
             placeholder="Напиши сообщение… (Enter — отправить, Shift+Enter — новая строка)"
             value={newMessage}
             onChange={handleMessageChange}
@@ -203,13 +206,12 @@ function ChatTab({ selected = null, userEmail }) {
           />
         </div>
         <div className="flex justify-end">
-          <button
-            className="btn btn-primary"
+          <Button
             disabled={sending || (!newMessage.trim() && !file)}
             onClick={handleSend}
           >
             {sending ? 'Отправка…' : 'Отправить'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -10,9 +10,7 @@ export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
     <Card>
       <CardHeader>
         <CardTitle>{item.name}</CardTitle>
-        <div className="text-sm text-base-content/70 transition-colors">
-          {item.location}
-        </div>
+        <div className="text-sm text-muted-foreground">{item.location}</div>
       </CardHeader>
       <CardContent className="flex justify-between items-center">
         <div className="flex space-x-2 mt-1 text-sm">

--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import Card from './Card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { Badge } from '@/components/ui/badge'
 
 function InventorySidebar({
   objects,
@@ -36,9 +37,9 @@ function InventorySidebar({
               {o.name}
             </button>
             {notifications[o.id] ? (
-              <span className="badge badge-error ml-2">
+              <Badge variant="destructive" className="ml-2">
                 {notifications[o.id]}
-              </span>
+              </Badge>
             ) : null}
           </div>
           <>

--- a/src/components/ObjectCard.jsx
+++ b/src/components/ObjectCard.jsx
@@ -6,9 +6,7 @@ function ObjectCard({ item }) {
   return (
     <Card>
       <h4 className="font-semibold">{item.name}</h4>
-      <p className="text-base-content/70 transition-colors">
-        {item.description}
-      </p>
+      <p className="text-muted-foreground">{item.description}</p>
     </Card>
   )
 }

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -2,10 +2,7 @@ export default function Spinner() {
   return (
     <div className="fixed inset-0 flex items-center justify-center">
       <div className="flex justify-center p-4" data-testid="spinner">
-        <svg
-          className="animate-spin h-5 w-5 text-primary transition-colors"
-          viewBox="0 0 24 24"
-        >
+        <svg className="animate-spin h-5 w-5 text-primary" viewBox="0 0 24 24">
           <circle
             className="opacity-25"
             cx="12"

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 
 /**
  * Format date string into locale friendly format.
@@ -18,15 +19,15 @@ function formatDate(dateStr) {
 }
 
 function TaskCard({ item, onEdit, onDelete, onView }) {
-  const badgeClass = useMemo(
+  const badgeVariant = useMemo(
     () =>
       ({
-        запланировано: 'badge-info',
-        'в процессе': 'badge-warning',
-        'в работе': 'badge-warning',
-        завершено: 'badge-success',
-        отменено: 'badge-error',
-      })[item.status] || 'badge',
+        запланировано: 'info',
+        'в процессе': 'warning',
+        'в работе': 'warning',
+        завершено: 'success',
+        отменено: 'destructive',
+      })[item.status] || 'default',
     [item.status],
   )
 
@@ -62,7 +63,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
 
   return (
     <Card
-      className="flex flex-col xs:flex-row md:flex-row justify-between items-start xs:items-center cursor-pointer hover:bg-base-200 transition-colors animate-fade-in"
+      className="flex flex-col xs:flex-row md:flex-row justify-between items-start xs:items-center cursor-pointer hover:bg-muted animate-fade-in"
       onClick={handleView}
     >
       <CardHeader className="flex-1">
@@ -70,7 +71,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
           {item.title}
         </CardTitle>
         {(assignee || dueDate) && (
-          <p className="text-sm text-base-content/70 transition-colors">
+          <p className="text-sm text-muted-foreground">
             {assignee && <span>👤 {assignee}</span>}
             {assignee && dueDate && ' • '}
             {dueDate && <span>📅 {formatDate(dueDate)}</span>}
@@ -78,7 +79,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
         )}
       </CardHeader>
       <CardContent className="flex flex-col xs:flex-row md:flex-row flex-wrap items-center gap-2 mt-2 xs:mt-0">
-        <span className={`badge ${badgeClass}`}>{item.status}</span>
+        <Badge variant={badgeVariant}>{item.status}</Badge>
         {canManage && (
           <>
             <Button

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { cva } from 'class-variance-authority'
+import { cn } from '../../utils/cn'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground border-transparent',
+        secondary: 'bg-secondary text-secondary-foreground border-transparent',
+        info: 'bg-sky-500 text-white border-transparent',
+        warning: 'bg-yellow-500 text-yellow-900 border-transparent',
+        success: 'bg-green-500 text-white border-transparent',
+        destructive:
+          'bg-destructive text-destructive-foreground border-transparent',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export const Badge = ({ className, variant, ...props }) => {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+Badge.propTypes = {
+  className: PropTypes.string,
+  variant: PropTypes.oneOf([
+    'default',
+    'secondary',
+    'info',
+    'warning',
+    'success',
+    'destructive',
+    'outline',
+  ]),
+}

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -34,7 +34,7 @@ export const DialogContent = React.forwardRef(function DialogContent(
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-base-100 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -11,7 +11,6 @@ import { Input } from '@/components/ui/input'
 
 import { Button } from '@/components/ui/button'
 
-
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
   const [userError, setUserError] = useState(null)
@@ -91,11 +90,11 @@ export default function AuthPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-center h-screen bg-base-200 transition-colors">
-        <div className="flex w-full min-h-screen items-center justify-center bg-base-100">
+      <div className="flex items-center justify-center h-screen bg-background">
+        <div className="flex w-full min-h-screen items-center justify-center bg-background">
           <form
             onSubmit={handleSubmit(onSubmit)}
-            className="bg-base-100 p-6 rounded shadow w-full max-w-sm space-y-4 transition-colors"
+            className="bg-card p-6 rounded shadow w-full max-w-sm space-y-4"
           >
             <h2 className="text-lg font-bold text-center">
               {isRegister ? 'Регистрация' : 'Вход'}
@@ -111,7 +110,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="email"
-                className="input input-bordered w-full"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 placeholder="Email"
                 {...register('email')}
               />
@@ -126,7 +125,7 @@ export default function AuthPage() {
               <div>
                 <Input
                   type="text"
-                  className="input input-bordered w-full"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                   placeholder="Имя пользователя"
                   {...register('username')}
                 />
@@ -141,7 +140,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="password"
-                className="input input-bordered w-full"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 placeholder="Пароль"
                 {...register('password')}
               />

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -98,7 +98,7 @@ export default function DashboardPage() {
 
   if (fetchError) {
     return (
-      <div className="flex w-full min-h-screen items-center justify-center bg-base-100 text-red-500">
+      <div className="flex w-full min-h-screen items-center justify-center bg-background text-red-500">
         {fetchError}
       </div>
     )
@@ -107,13 +107,13 @@ export default function DashboardPage() {
   if (!selected) {
     if (isEmpty) {
       return (
-        <div className="flex w-full min-h-screen items-center justify-center bg-base-100 text-gray-500">
+        <div className="flex w-full min-h-screen items-center justify-center bg-background text-gray-500">
           Объекты отсутствуют
         </div>
       )
     }
     return (
-      <div className="flex w-full min-h-screen items-center justify-center bg-base-100 text-gray-500">
+      <div className="flex w-full min-h-screen items-center justify-center bg-background text-gray-500">
         Загрузка объектов...
       </div>
     )
@@ -121,8 +121,8 @@ export default function DashboardPage() {
 
   return (
     <>
-      <div className="flex h-screen bg-base-100 transition-colors">
-        <aside className="hidden md:flex flex-col w-72 bg-base-200 p-4 border-r shadow-lg overflow-y-auto transition-colors">
+      <div className="flex h-screen bg-background">
+        <aside className="hidden md:flex flex-col w-72 bg-muted p-4 border-r shadow-lg overflow-y-auto">
           <InventorySidebar
             objects={objects}
             selected={selected}
@@ -138,7 +138,7 @@ export default function DashboardPage() {
               className="fixed inset-0 bg-black bg-opacity-50"
               onClick={toggleSidebar}
             />
-            <aside className="relative z-20 w-72 bg-base-200 p-4 shadow-lg overflow-y-auto transition-colors">
+            <aside className="relative z-20 w-72 bg-muted p-4 shadow-lg overflow-y-auto">
               <Button
                 size="icon"
                 className="absolute right-2 top-2"
@@ -159,7 +159,7 @@ export default function DashboardPage() {
         )}
 
         <div className="flex-1 flex flex-col">
-          <header className="flex flex-col xs:items-start xs:gap-2 md:flex-row items-center justify-between p-4 border-b bg-base-100 transition-colors">
+          <header className="flex flex-col xs:items-start xs:gap-2 md:flex-row items-center justify-between p-4 border-b bg-background">
             <div className="flex items-center gap-2">
               <button className="md:hidden p-2 text-lg" onClick={toggleSidebar}>
                 ☰

--- a/src/pages/MissingEnvPage.jsx
+++ b/src/pages/MissingEnvPage.jsx
@@ -22,8 +22,8 @@ export default function MissingEnvPage() {
   const targetsText = targets.join(' и ')
 
   return (
-    <div className="flex h-screen items-center justify-center bg-base-200 transition-colors">
-      <div className="flex w-full min-h-screen items-center justify-center bg-base-200">
+    <div className="flex h-screen items-center justify-center bg-background">
+      <div className="flex w-full min-h-screen items-center justify-center bg-background">
         <div className="space-y-4 max-w-md text-center">
           <div className="alert alert-error shadow-lg">
             <span>


### PR DESCRIPTION
## Summary
- swap chat tab markup to Button/Input/Textarea components and custom styles
- introduce Badge component and use it for task status and notifications
- drop DaisyUI `base-*` classes and transitions across pages and dialogs

## Testing
- `npm test` *(fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts', and other errors)*
- `npm run build`
- `rg "base-" src index.html`

------
https://chatgpt.com/codex/tasks/task_e_68adb5df6f988324aef1113e4cf87004