### PR TITLE
feat: replace tabs with radix implementation

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -164,19 +164,11 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
 
   return (
     <Tabs value={tab} onValueChange={setTab} className="flex flex-col h-full">
-      <TabsList className="mb-4 flex gap-2">
-        <TabsTrigger value="desc" className="tab tab-bordered">
-          Описание
-        </TabsTrigger>
-        <TabsTrigger value="hw" className="tab tab-bordered">
-          Железо
-        </TabsTrigger>
-        <TabsTrigger value="tasks" className="tab tab-bordered">
-          Задачи
-        </TabsTrigger>
-        <TabsTrigger value="chat" className="tab tab-bordered">
-          Чат
-        </TabsTrigger>
+      <TabsList className="mb-4">
+        <TabsTrigger value="desc">Описание</TabsTrigger>
+        <TabsTrigger value="hw">Железо</TabsTrigger>
+        <TabsTrigger value="tasks">Задачи</TabsTrigger>
+        <TabsTrigger value="chat">Чат</TabsTrigger>
       </TabsList>
 
       <TabsContent value="desc" className="flex-1 overflow-auto">

--- a/src/components/ui/tabs.jsx
+++ b/src/components/ui/tabs.jsx
@@ -1,73 +1,44 @@
-import React, { createContext, useContext } from 'react'
-import PropTypes from 'prop-types'
-import { cn } from '../../utils/cn'
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
 
-const TabsContext = createContext()
+import { cn } from '@/utils/cn'
 
-function Tabs({ value, onValueChange, children, className, ...props }) {
-  return (
-    <TabsContext.Provider value={{ value, onValueChange }}>
-      <div className={cn(className)} {...props}>
-        {children}
-      </div>
-    </TabsContext.Provider>
-  )
-}
+const Tabs = TabsPrimitive.Root
 
-Tabs.propTypes = {
-  value: PropTypes.string.isRequired,
-  onValueChange: PropTypes.func.isRequired,
-  children: PropTypes.node,
-  className: PropTypes.string,
-}
+const TabsList = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
 
-function TabsList({ children, className, ...props }) {
-  return (
-    <div className={cn(className)} {...props}>
-      {children}
-    </div>
-  )
-}
+const TabsTrigger = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
-TabsList.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-}
-
-function TabsTrigger({ value, children, className, ...props }) {
-  const { value: active, onValueChange } = useContext(TabsContext)
-  const activeClass = active === value ? 'tab-active' : ''
-  return (
-    <button
-      className={cn(className, activeClass)}
-      onClick={() => onValueChange(value)}
-      {...props}
-    >
-      {children}
-    </button>
-  )
-}
-
-TabsTrigger.propTypes = {
-  value: PropTypes.string.isRequired,
-  children: PropTypes.node,
-  className: PropTypes.string,
-}
-
-function TabsContent({ value, children, className, ...props }) {
-  const { value: active } = useContext(TabsContext)
-  if (active !== value) return null
-  return (
-    <div className={cn(className)} {...props}>
-      {children}
-    </div>
-  )
-}
-
-TabsContent.propTypes = {
-  value: PropTypes.string.isRequired,
-  children: PropTypes.node,
-  className: PropTypes.string,
-}
+const TabsContent = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- replace custom tabs with Radix/Shadcn version using cn util
- adjust InventoryTabs to new tab component

## Testing
- `npm test` (fails: ChatTab.test.jsx, ConfirmModal.test.jsx, Dialog.test.jsx, InventoryTabs.test.jsx, etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adb5e0ddf88324b2850fd126c064b3