### PR TITLE
refactor: заменить классы input/textarea на className

### DIFF
--- a/src/components/ChatTab.jsx
+++ b/src/components/ChatTab.jsx
@@ -4,6 +4,8 @@ import { linkifyText } from '../utils/linkify.jsx'
 import AttachmentPreview from './AttachmentPreview.jsx'
 import { PaperClipIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import useChat from '../hooks/useChat.js'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 
 function ChatTab({ selected = null, userEmail }) {
   const objectId = selected?.id || null
@@ -82,9 +84,9 @@ function ChatTab({ selected = null, userEmail }) {
           }`}
         >
           {isSearchOpen && (
-            <input
+            <Input
               type="text"
-              className="input input-bordered input-sm w-full"
+              className="w-full h-8 text-sm"
               placeholder="Поиск сообщений"
               value={searchInput}
               onChange={handleSearchChange}
@@ -194,8 +196,8 @@ function ChatTab({ selected = null, userEmail }) {
             ref={fileInputRef}
             onChange={handleFileChange}
           />
-          <textarea
-            className="textarea textarea-bordered w-full min-h-24"
+          <Textarea
+            className="w-full min-h-24"
             placeholder="Напиши сообщение… (Enter — отправить, Shift+Enter — новая строка)"
             value={newMessage}
             onChange={handleMessageChange}

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -11,7 +11,6 @@ import { Input } from '@/components/ui/input'
 
 import { Button } from '@/components/ui/button'
 
-
 export default function AuthPage() {
   const [isRegister, setIsRegister] = useState(false)
   const [userError, setUserError] = useState(null)
@@ -111,7 +110,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="email"
-                className="input input-bordered w-full"
+                className="w-full"
                 placeholder="Email"
                 {...register('email')}
               />
@@ -126,7 +125,7 @@ export default function AuthPage() {
               <div>
                 <Input
                   type="text"
-                  className="input input-bordered w-full"
+                  className="w-full"
                   placeholder="Имя пользователя"
                   {...register('username')}
                 />
@@ -141,7 +140,7 @@ export default function AuthPage() {
             <div>
               <Input
                 type="password"
-                className="input input-bordered w-full"
+                className="w-full"
                 placeholder="Пароль"
                 {...register('password')}
               />


### PR DESCRIPTION
## Summary
- убрать `input*` и `textarea*` классы в формах авторизации и чата
- использовать компоненты `Input`/`Textarea` shadcn с `className`

## Testing
- `npm test` *(fail: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')*
- `npx eslint src/pages/AuthPage.jsx src/components/ChatTab.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68adb5e708a88324a74fe3cf7afb450e