### PR TITLE
test: use @ alias in tests

### DIFF
--- a/tests/AuditTrail.test.jsx
+++ b/tests/AuditTrail.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import AuditTrail from '../src/components/AuditTrail.jsx'
+import AuditTrail from '@/components/AuditTrail.jsx'
 
 const mockLogs = [
   {
@@ -13,7 +13,7 @@ const mockLogs = [
   },
 ]
 
-jest.mock('../src/supabaseClient.js', () => {
+jest.mock('@/supabaseClient.js', () => {
   const mockLimit = jest.fn(() =>
     Promise.resolve({ data: mockLogs, error: null }),
   )

--- a/tests/AuthContext.test.jsx
+++ b/tests/AuthContext.test.jsx
@@ -1,14 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, jest } from '@jest/globals'
 import { useContext } from 'react'
-import { AuthProvider, AuthContext } from '../src/context/AuthContext.jsx'
+import { AuthProvider, AuthContext } from '@/context/AuthContext.jsx'
 import { toast } from 'react-hot-toast'
-import logger from '../src/utils/logger.js'
+import logger from '@/utils/logger.js'
 
 const mockGetSession = jest.fn()
 const mockOnAuthStateChange = jest.fn()
 
-jest.mock('../src/supabaseClient.js', () => ({
+jest.mock('@/supabaseClient.js', () => ({
   supabase: {
     auth: {
       getSession: (...args) => mockGetSession(...args),

--- a/tests/ChatTab.test.jsx
+++ b/tests/ChatTab.test.jsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, waitFor, screen, act } from '@testing-library/react'
-import ChatTab from '../src/components/ChatTab.jsx'
+import ChatTab from '@/components/ChatTab.jsx'
 
 const mockMessages = [
   {
@@ -22,7 +22,7 @@ const mockMessages = [
 var mockInsert
 var mockFetchMessages
 
-jest.mock('../src/supabaseClient.js', () => {
+jest.mock('@/supabaseClient.js', () => {
   mockInsert = jest.fn((records) => {
     const record = records[0]
     return {
@@ -64,7 +64,7 @@ jest.mock('../src/supabaseClient.js', () => {
   }
 })
 
-jest.mock('../src/hooks/useChatMessages.js', () => {
+jest.mock('@/hooks/useChatMessages.js', () => {
   mockFetchMessages = jest.fn(() =>
     Promise.resolve({ data: mockMessages, error: null }),
   )

--- a/tests/Dialog.test.jsx
+++ b/tests/Dialog.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { Dialog, DialogContent } from '../src/components/ui/dialog.jsx'
+import { Dialog, DialogContent } from '@/components/ui/dialog.jsx'
 
 describe('Dialog', () => {
   it('открывается и закрывается через проп open', () => {

--- a/tests/ErrorBoundary.test.jsx
+++ b/tests/ErrorBoundary.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import ErrorBoundary from '@/components/ErrorBoundary'
-import logger from '../src/utils/logger.js'
+import logger from '@/utils/logger.js'
 
 function ProblemComponent() {
   throw new Error('Test error')

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -5,14 +5,14 @@ import '@testing-library/jest-dom'
 
 var mockLoadHardware, mockFetchMessages, mockNavigate
 
-jest.mock('../src/hooks/usePersistedForm.js', () => () => ({
+jest.mock('@/hooks/usePersistedForm.js', () => () => ({
   register: jest.fn(),
   handleSubmit: (fn) => fn,
   reset: jest.fn(),
   formState: { errors: {} },
 }))
 
-jest.mock('../src/hooks/useHardware.js', () => {
+jest.mock('@/hooks/useHardware.js', () => {
   mockLoadHardware = jest.fn().mockResolvedValue({ data: [], error: null })
 
   return {
@@ -28,7 +28,7 @@ jest.mock('../src/hooks/useHardware.js', () => {
   }
 })
 
-jest.mock('../src/hooks/useTasks.js', () => {
+jest.mock('@/hooks/useTasks.js', () => {
   const tasks = []
   const mocked = {
     tasks,
@@ -43,7 +43,7 @@ jest.mock('../src/hooks/useTasks.js', () => {
   return { useTasks: () => mocked }
 })
 
-jest.mock('../src/hooks/useChatMessages.js', () => {
+jest.mock('@/hooks/useChatMessages.js', () => {
   mockFetchMessages = jest.fn().mockResolvedValue({ data: [], error: null })
   return {
     useChatMessages: () => ({
@@ -53,11 +53,11 @@ jest.mock('../src/hooks/useChatMessages.js', () => {
   }
 })
 
-jest.mock('../src/hooks/useObjects.js', () => ({
+jest.mock('@/hooks/useObjects.js', () => ({
   useObjects: () => ({ updateObject: jest.fn() }),
 }))
 
-jest.mock('../src/hooks/useAuth.js', () => ({
+jest.mock('@/hooks/useAuth.js', () => ({
   useAuth: () => ({ user: { id: 'u1', email: 'me@example.com' } }),
 }))
 
@@ -72,7 +72,7 @@ jest.mock('react-router-dom', () => {
 
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import InventoryTabs from '../src/components/InventoryTabs.jsx'
+import InventoryTabs from '@/components/InventoryTabs.jsx'
 
 describe('InventoryTabs', () => {
   const selected = { id: 1, name: 'Объект 1' }

--- a/tests/TasksTab.test.jsx
+++ b/tests/TasksTab.test.jsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import TasksTab from '../src/components/TasksTab.jsx'
+import TasksTab from '@/components/TasksTab.jsx'
 
 var mockTasks = [],
   mockLoadTasks,
@@ -9,7 +9,7 @@ var mockTasks = [],
   mockUpdateTask
 const mockNavigate = jest.fn()
 
-jest.mock('../src/hooks/useTasks.js', () => {
+jest.mock('@/hooks/useTasks.js', () => {
   mockTasks = []
   mockLoadTasks = jest.fn()
   mockCreateTask = jest.fn()
@@ -28,7 +28,7 @@ jest.mock('../src/hooks/useTasks.js', () => {
   }
 })
 
-jest.mock('../src/hooks/useAuth.js', () => ({
+jest.mock('@/hooks/useAuth.js', () => ({
   useAuth: () => ({ user: { id: 'u1', email: 'me@example.com' } }),
 }))
 

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -6,7 +6,7 @@ const mockEq = jest.fn(() => ({ maybeSingle: mockMaybeSingle }))
 const mockSelect = jest.fn(() => ({ eq: mockEq }))
 const mockFrom = jest.fn(() => ({ select: mockSelect }))
 
-jest.mock('../src/supabaseClient.js', () => ({
+jest.mock('@/supabaseClient.js', () => ({
   supabase: {
     auth: { getSession: mockGetSession },
     from: mockFrom,
@@ -14,7 +14,7 @@ jest.mock('../src/supabaseClient.js', () => ({
   isSupabaseConfigured: true,
 }))
 
-jest.mock('../src/apiConfig.js', () => ({
+jest.mock('@/apiConfig.js', () => ({
   apiBaseUrl: 'http://localhost',
   isApiConfigured: true,
 }))
@@ -24,7 +24,7 @@ let fetchSession, fetchRole, __resetCache
 beforeEach(async () => {
   jest.resetModules()
   globalThis.fetch = jest.fn()
-  const mod = await import('../src/services/authService.js')
+  const mod = await import('@/services/authService.js')
   fetchSession = mod.fetchSession
   fetchRole = mod.fetchRole
   __resetCache = mod.__resetCache

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 /* globals process */
-import logger from '../src/utils/logger.js'
+import logger from '@/utils/logger.js'
 
 describe('logger', () => {
   let infoSpy

--- a/tests/useChat.test.jsx
+++ b/tests/useChat.test.jsx
@@ -2,7 +2,7 @@
 let mockSupabase
 let onPayload
 
-jest.mock('../src/supabaseClient.js', () => ({
+jest.mock('@/supabaseClient.js', () => ({
   get supabase() {
     return mockSupabase
   },
@@ -52,7 +52,7 @@ mockSupabase = {
   removeChannel: jest.fn(),
 }
 
-jest.mock('../src/utils/handleSupabaseError', () => ({
+jest.mock('@/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
 }))
 
@@ -91,7 +91,7 @@ const mockFetchMessages = jest
 const mockSendMessage = jest.fn()
 
 // Mock the useChatMessages hook
-jest.mock('../src/hooks/useChatMessages.js', () => ({
+jest.mock('@/hooks/useChatMessages.js', () => ({
   useChatMessages: () => ({
     fetchMessages: mockFetchMessages,
     sendMessage: mockSendMessage,
@@ -101,8 +101,8 @@ jest.mock('../src/hooks/useChatMessages.js', () => ({
 // Now import the components
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, beforeEach, jest } from '@jest/globals'
-import useChat from '../src/hooks/useChat.js'
-import { handleSupabaseError as mockHandleSupabaseError } from '../src/utils/handleSupabaseError'
+import useChat from '@/hooks/useChat.js'
+import { handleSupabaseError as mockHandleSupabaseError } from '@/utils/handleSupabaseError'
 
 describe('useChat markMessagesAsRead', () => {
   beforeEach(() => {

--- a/tests/useChatMessages.test.js
+++ b/tests/useChatMessages.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 import { renderHook } from '@testing-library/react'
-import { useChatMessages } from '../src/hooks/useChatMessages.js'
-import { handleSupabaseError as mockHandleSupabaseError } from '../src/utils/handleSupabaseError'
+import { useChatMessages } from '@/hooks/useChatMessages.js'
+import { handleSupabaseError as mockHandleSupabaseError } from '@/utils/handleSupabaseError'
 
-jest.mock('../src/utils/handleSupabaseError', () => ({
+jest.mock('@/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
 }))
 
@@ -23,7 +23,7 @@ var mockSelect
 var mockInsert
 var mockSupabaseFrom
 
-jest.mock('../src/supabaseClient.js', () => {
+jest.mock('@/supabaseClient.js', () => {
   mockUpload = jest.fn(() => Promise.resolve({ data: null, error: null }))
   mockGetPublicUrl = jest.fn(() => ({ data: { publicUrl: 'url' } }))
   mockStorageFrom = jest.fn(() => ({

--- a/tests/useHardware.test.js
+++ b/tests/useHardware.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 import { renderHook } from '@testing-library/react'
-import { useHardware } from '../src/hooks/useHardware.js'
-import { handleSupabaseError as mockHandleSupabaseError } from '../src/utils/handleSupabaseError'
+import { useHardware } from '@/hooks/useHardware.js'
+import { handleSupabaseError as mockHandleSupabaseError } from '@/utils/handleSupabaseError'
 
-jest.mock('../src/utils/handleSupabaseError', () => ({
+jest.mock('@/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
 }))
 
@@ -16,7 +16,7 @@ var mockEq
 var mockSelect
 var mockFrom
 
-jest.mock('../src/supabaseClient.js', () => {
+jest.mock('@/supabaseClient.js', () => {
   mockOrder = jest.fn(() => Promise.resolve({ data: null, error: null }))
   mockEq = jest.fn(() => ({ order: mockOrder }))
   mockSelect = jest.fn(() => ({ eq: mockEq }))

--- a/tests/useSupabaseQuery.test.js
+++ b/tests/useSupabaseQuery.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals'
 import { renderHook, act } from '@testing-library/react'
-import { useSupabaseQuery } from '../src/utils/useSupabaseQuery.js'
+import { useSupabaseQuery } from '@/utils/useSupabaseQuery.js'
 
 describe('useSupabaseQuery', () => {
   it('не выставляет ошибку при отмене запроса', async () => {

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 import { renderHook } from '@testing-library/react'
-import { useTasks } from '../src/hooks/useTasks.js'
-import { handleSupabaseError as mockHandleSupabaseError } from '../src/utils/handleSupabaseError'
+import { useTasks } from '@/hooks/useTasks.js'
+import { handleSupabaseError as mockHandleSupabaseError } from '@/utils/handleSupabaseError'
 
-jest.mock('../src/utils/handleSupabaseError', () => ({
+jest.mock('@/utils/handleSupabaseError', () => ({
   handleSupabaseError: jest.fn(),
 }))
 
@@ -20,7 +20,7 @@ var mockOrder
 var mockRangeOrder
 var mockRangeBase
 
-jest.mock('../src/supabaseClient.js', () => {
+jest.mock('@/supabaseClient.js', () => {
   mockSingle = jest.fn(() => Promise.resolve({ data: null, error: null }))
   mockRangeOrder = jest.fn(() => Promise.resolve({ data: null, error: null }))
   mockRangeBase = jest.fn(() => Promise.resolve({ data: null, error: null }))


### PR DESCRIPTION
## Summary
- replace relative `../src` imports in tests with `@`
- confirm jest/vitest configuration handles `@` alias

## Testing
- `npm test` *(fails: Test Suites: 6 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5ea47988324acd0dee3b6c58db7