### PR TITLE
chore: remove transition-colors from ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -34,7 +34,7 @@ export default function ThemeToggle() {
   return (
     <Button
       size="sm"
-      className="transition-colors"
+      className="transition-none"
       onClick={toggleTheme}
       aria-label="Переключить тему"
     >


### PR DESCRIPTION
## Summary
- replace `transition-colors` with `transition-none` in ThemeToggle button

## Testing
- `npm test` (fails: Test Suites: 13 failed, 15 passed)
- `npm run build` (fails: Transform failed with 1 error: button.jsx:43)
- `rg "transition-colors" src index.html`

------
https://chatgpt.com/codex/tasks/task_e_68adca7daa3c8324a0524b5885349469