### PR TITLE
fix: remove duplicate button in theme toggle

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -32,8 +32,7 @@ export default function ThemeToggle() {
   }
 
   return (
-    <Button size="sm" onClick={toggleTheme} aria-label="Переключить тему">
-   <Button
+    <Button
       size="sm"
       className="transition-none"
       onClick={toggleTheme}


### PR DESCRIPTION
## Summary
- remove duplicate Button component from ThemeToggle

## Testing
- `npm run build`
- `npm test` *(fails: 6 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9739d2288324bb819930b3282ae4