### PR TITLE
test: restore global fetch after auth service tests

### DIFF
--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals'
 
 const mockGetSession = jest.fn()
 const mockMaybeSingle = jest.fn()
@@ -20,6 +27,7 @@ jest.mock('@/apiConfig.js', () => ({
 }))
 
 let fetchSession, fetchRole, __resetCache
+const originalFetch = globalThis.fetch
 
 beforeEach(async () => {
   jest.resetModules()
@@ -34,6 +42,10 @@ beforeEach(async () => {
   mockEq.mockClear()
   mockSelect.mockClear()
   mockFrom.mockClear()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
 })
 
 describe('authService', () => {


### PR DESCRIPTION
## Summary
- save original global fetch before authService tests
- restore global fetch after each authService test

## Testing
- `npm test` *(fails: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b0065548324a9e315809e5b5e1a