### PR TITLE
test: polyfill File in test setup

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -2,6 +2,15 @@
 /* globals process */
 import '@testing-library/jest-dom'
 
+if (typeof File === 'undefined') {
+  globalThis.File = class File extends Blob {
+    constructor(parts, name, opts) {
+      super(parts, opts)
+      this.name = name
+    }
+  }
+}
+
 process.env.VITE_API_BASE_URL = 'http://localhost'
 process.env.VITE_SUPABASE_URL = 'http://localhost'
 process.env.VITE_SUPABASE_ANON_KEY = 'test-key'


### PR DESCRIPTION
## Summary
- add File polyfill for Node-based Jest tests

## Testing
- `npm test tests/useChatMessages.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae9b02e30483249c15933695823ee4