### PR TITLE
Use string ids for inventory component PropTypes

### DIFF
--- a/src/components/InventorySidebar.jsx
+++ b/src/components/InventorySidebar.jsx
@@ -70,12 +70,12 @@ export default memo(InventorySidebar)
 InventorySidebar.propTypes = {
   objects: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
+      id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
     }),
   ).isRequired,
   selected: PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   }),
   onSelect: PropTypes.func.isRequired,

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -327,7 +327,7 @@ function InventoryTabs({ selected, onUpdateSelected, onTabChange = () => {} }) {
 
 InventoryTabs.propTypes = {
   selected: PropTypes.shape({
-    id: PropTypes.number,
+    id: PropTypes.string,
     name: PropTypes.string,
     description: PropTypes.string,
   }),

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -81,12 +81,13 @@ jest.mock('react-router-dom', () => {
   return { ...actual, useNavigate: () => mockNavigate }
 })
 
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import InventoryTabs from '@/components/InventoryTabs.jsx'
 
 describe('InventoryTabs', () => {
-  const selected = { id: 1, name: 'Объект 1' }
+  const selected = { id: '1', name: 'Объект 1' }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -106,10 +107,10 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Железо' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Железо' }))
     expect(await screen.findByText('Оборудование')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Задачи' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Задачи' }))
     expect(
       await screen.findByRole('heading', { name: /Задачи/ }),
     ).toBeInTheDocument()
@@ -128,7 +129,7 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Задачи' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Задачи' }))
     expect(
       await screen.findByText('Нет задач для этого объекта.'),
     ).toBeInTheDocument()
@@ -147,7 +148,7 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Чат' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Чат' }))
     expect(
       screen.getByPlaceholderText(
         'Напиши сообщение… (Enter — отправить, Shift+Enter — новая строка)',
@@ -168,8 +169,8 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Железо' }))
-    fireEvent.click(screen.getByRole('button', { name: /Добавить/ }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Железо' }))
+    await userEvent.click(screen.getByRole('button', { name: /Добавить/ }))
     expect(screen.getByPlaceholderText('Название')).toHaveClass('w-full')
     expect(screen.getByPlaceholderText('Расположение')).toHaveClass('w-full')
   })
@@ -177,7 +178,7 @@ describe('InventoryTabs', () => {
   it('открывает форму редактирования оборудования', async () => {
     mockHardware = [
       {
-        id: 1,
+        id: '1',
         name: 'Принтер',
         location: 'Офис',
         purchase_status: 'не оплачен',
@@ -197,9 +198,9 @@ describe('InventoryTabs', () => {
       </MemoryRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Железо' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Железо' }))
     const editBtn = await screen.findByRole('button', { name: 'Изменить' })
-    fireEvent.click(editBtn)
+    await userEvent.click(editBtn)
     expect(screen.getByPlaceholderText('Название')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- adjust `InventoryTabs` `selected` prop shape to expect string `id`
- update `InventorySidebar` to validate object ids as strings
- align InventoryTabs tests with string ids and tab roles

## Testing
- `npm test tests/InventoryTabs.test.jsx`
- `npm test tests/ExportImport.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68aea5b5607883249d7f12efe0e0fc10