### PR TITLE
refactor: use import meta env for logger

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,5 +1,3 @@
-/* globals process */
-
 const levels = {
   none: 0,
   error: 1,
@@ -7,11 +5,15 @@ const levels = {
   info: 3,
 }
 
+let forcedLevel
+
+export function setLogLevel(level) {
+  forcedLevel = level
+}
+
 function getEnvLevel() {
-  const level =
-    import.meta.env?.VITE_LOG_LEVEL ||
-    process?.env?.LOG_LEVEL ||
-    process?.env?.VITE_LOG_LEVEL
+  if (forcedLevel) return forcedLevel.toLowerCase()
+  const level = import.meta.env?.VITE_LOG_LEVEL
   return (level || 'info').toLowerCase()
 }
 

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,12 +1,9 @@
-/* eslint-env node */
-/* globals process */
-import logger from '@/utils/logger.js'
+import logger, { setLogLevel } from '@/utils/logger.js'
 
 describe('logger', () => {
   let infoSpy
   let warnSpy
   let errorSpy
-  const originalEnv = { ...process.env }
 
   beforeEach(() => {
     infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
@@ -18,11 +15,10 @@ describe('logger', () => {
     infoSpy.mockRestore()
     warnSpy.mockRestore()
     errorSpy.mockRestore()
-    process.env = { ...originalEnv }
+    setLogLevel(undefined)
   })
 
   test('по умолчанию логирует все уровни', () => {
-    delete process.env.LOG_LEVEL
     logger.info('i')
     logger.warn('w')
     logger.error('e')
@@ -32,7 +28,7 @@ describe('logger', () => {
   })
 
   test('уровень warn отключает info', () => {
-    process.env.LOG_LEVEL = 'warn'
+    setLogLevel('warn')
     logger.info('i')
     logger.warn('w')
     logger.error('e')
@@ -42,7 +38,7 @@ describe('logger', () => {
   })
 
   test('уровень error отключает warn и info', () => {
-    process.env.LOG_LEVEL = 'error'
+    setLogLevel('error')
     logger.info('i')
     logger.warn('w')
     logger.error('e')
@@ -52,7 +48,7 @@ describe('logger', () => {
   })
 
   test('уровень none отключает все', () => {
-    process.env.LOG_LEVEL = 'none'
+    setLogLevel('none')
     logger.info('i')
     logger.warn('w')
     logger.error('e')


### PR DESCRIPTION
## Summary
- remove `process.env` references from logger and rely on `import.meta.env`
- allow overriding log level via `setLogLevel`
- update logger tests for new API

## Testing
- `npm test` *(fails: 7 failed, 21 passed)*
- `npm test tests/logger.test.js`
- `npm run build`
- `node -e "import('./src/utils/logger.js').then(m=>{m.setLogLevel('warn');m.default.info('i');m.default.warn('w');})"`


------
https://chatgpt.com/codex/tasks/task_e_68aea5b6ad248324869912e604cd30e7