### PR TITLE
feat: add due date to tasks

### DIFF
--- a/supabase/migrations/20250827174914_add_due_date_to_tasks.sql
+++ b/supabase/migrations/20250827174914_add_due_date_to_tasks.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS due_date date;
+
+UPDATE tasks
+SET due_date = NOW()::date
+WHERE due_date IS NULL;


### PR DESCRIPTION
## Summary
- add migration to include `due_date` column in `tasks` table and backfill existing rows

## Testing
- `npm test` *(fails: ConfirmModal test failing; missing Deno module)*
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68af44fc818c8324960067da1adfa4b9