### PR TITLE
feat: skip task fetch when object id missing

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -16,6 +16,7 @@ export function useTasks(objectId) {
 
   const fetchTasks = async (objId, offset = 0, limit = 20) => {
     try {
+      if (!objId) return { data: [], error: null }
       const baseFields =
         'id, title, status, assignee, due_date, notes, created_at'
       const baseQuery = supabase
@@ -128,6 +129,12 @@ export function useTasks(objectId) {
   const loadTasks = useCallback(
     async ({ offset = 0, limit = 20 } = {}) => {
       setLoading(true)
+      if (!objectId) {
+        setTasks([])
+        setError(null)
+        setLoading(false)
+        return { data: [], error: null }
+      }
       const { data, error: err } = await fetchTasks(objectId, offset, limit)
       if (err) {
         setError(err.message || 'Ошибка загрузки задач')


### PR DESCRIPTION
## Summary
- return empty result when `objId` is missing in `fetchTasks`
- avoid calling `fetchTasks` in `loadTasks` when `objectId` is absent

## Testing
- `npm test` *(fails: ConfirmModal.test.jsx, supabase/functions/export/index.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a63a5f48324b48dc627f9c59630