### PR TITLE
Добавлена прокрутка содержимого модалки в DialogContent

### DIFF
--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -34,7 +34,7 @@ export const DialogContent = React.forwardRef(function DialogContent(
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg max-h-screen overflow-y-auto -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- добавлены классы `max-h-screen` и `overflow-y-auto` в `DialogContent`

## Testing
- `npm test` *(failed: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts', ConfirmModal test failure)*
- `npm run lint` *(failed: 13 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b6559e48324a3e3b62c5d4bf25f