### PR TITLE
Добавить внутренний отступ для вкладок на главной странице

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -212,7 +212,7 @@ export default function DashboardPage() {
             </div>
           </header>
 
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto p-4">
             <InventoryTabs
               selected={selected}
               onUpdateSelected={onUpdateSelected}


### PR DESCRIPTION
## Summary
- добавить отступы вокруг компонента InventoryTabs на странице Dashboard

## Testing
- `npm test -- --color=false | tee /tmp/unit.log | tail -n 5` *(падает: Cannot find module 'https://deno.land/std@0.177.0/testing/asserts.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68af4b6ac75c8324839828b324253b4c