### PR TITLE
Исправлено центрирование модального окна

### DIFF
--- a/src/components/__tests__/ConfirmModal.test.jsx
+++ b/src/components/__tests__/ConfirmModal.test.jsx
@@ -83,6 +83,6 @@ describe('ConfirmModal', () => {
     render(
       <ConfirmModal open={false} onConfirm={() => {}} onCancel={() => {}} />,
     )
-    expect(screen.getByTestId('dialog')).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument()
   })
 })

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -33,21 +33,13 @@ export const DialogContent = React.forwardRef(function DialogContent(
       <DialogOverlay />
       <DialogPrimitive.Content
         ref={ref}
-        className="fixed inset-0 z-50 flex items-center justify-center"
         className={cn(
           'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg max-h-screen overflow-y-auto -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}
       >
-        <div
-          className={cn(
-            'grid w-full max-w-lg gap-4 rounded-md bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-            className,
-          )}
-        >
-          {children}
-        </div>
+        {children}
       </DialogPrimitive.Content>
     </DialogPrimitive.Portal>
   )


### PR DESCRIPTION
## Изменения
- Удалён дублирующий атрибут `className` и лишний контейнер в DialogContent
- Обновлён тест ConfirmModal для проверки скрытого состояния

## Тестирование
- `npx jest tests/Dialog.test.jsx src/components/__tests__/ConfirmModal.test.jsx --runInBand --color=false`

------
https://chatgpt.com/codex/tasks/task_e_68af50d0e9348324bd9fa158e65681ce