### PR TITLE
очистка таймеров в useChat

### DIFF
--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -190,6 +190,10 @@ export default function useChat({ objectId, userEmail, search }) {
       if (channelRef.current) {
         supabase.removeChannel(channelRef.current)
       }
+      Object.values(optimisticTimersRef.current).forEach((timer) => {
+        clearTimeout(timer)
+      })
+      optimisticTimersRef.current = {}
     }
   }, [objectId, loadMore, autoScrollToBottom])
 


### PR DESCRIPTION
## Summary
- очищаем оптимистичные таймеры при отписке от канала, чтобы избежать setState после unmount

## Testing
- `npx jest tests/useChat.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68b001d280408324bd6da6828587be12