### PR TITLE
refactor: заменить console на logger

### DIFF
--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -6,6 +6,7 @@ import ErrorMessage from './ErrorMessage'
 import ConfirmModal from './ConfirmModal'
 import { useTasks } from '@/hooks/useTasks'
 import { useAuth } from '@/hooks/useAuth'
+import logger from '@/utils/logger'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -98,7 +99,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
         }
         closeTaskModal()
       } catch (err) {
-        console.error('Error saving task:', err)
+        logger.error('Error saving task:', err)
       }
     },
     [
@@ -129,7 +130,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
         await deleteTask(taskDeleteId)
         setTaskDeleteId(null)
       } catch (err) {
-        console.error('Error deleting task:', err)
+        logger.error('Error deleting task:', err)
       }
     }
   }, [taskDeleteId, deleteTask])

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { supabase } from '@/supabaseClient'
 import { handleSupabaseError } from '@/utils/handleSupabaseError'
+import logger from '@/utils/logger'
 import { useChatMessages } from './useChatMessages.js'
 
 export default function useChat({ objectId, userEmail, search }) {
@@ -35,7 +36,7 @@ export default function useChat({ objectId, userEmail, search }) {
       const { data, error } = await fetchMessages(objectId, params)
       if (currentSearch !== activeSearchRef.current) return
       if (error) {
-        console.error('loadMore error', {
+        logger.error('loadMore error', {
           name: error.name,
           message: error.message,
           stack: error.stack,
@@ -176,7 +177,7 @@ export default function useChat({ objectId, userEmail, search }) {
         },
       )
       .subscribe((status) => {
-        console.log('Channel status:', status)
+        logger.info('Channel status:', status)
         if (status === 'SUBSCRIBED') {
           loadMore().then(() => {
             setTimeout(() => autoScrollToBottom(true), 0)

--- a/src/hooks/useChatMessages.js
+++ b/src/hooks/useChatMessages.js
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { supabase } from '@/supabaseClient'
 import { handleSupabaseError } from '@/utils/handleSupabaseError'
+import logger from '@/utils/logger'
 import { useNavigate } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 import { toast } from 'react-hot-toast'
@@ -29,7 +30,7 @@ export function useChatMessages() {
             .order('created_at', { ascending: false })
         } catch (error) {
           if (error instanceof TypeError) {
-            console.error('Supabase unavailable', {
+            logger.error('Supabase unavailable', {
               name: error.name,
               message: error.message,
               stack: error.stack,
@@ -57,7 +58,7 @@ export function useChatMessages() {
         if (result.data) result.data.reverse()
         return result
       } catch (error) {
-        console.error('fetchMessages error', {
+        logger.error('fetchMessages error', {
           name: error.name,
           message: error.message,
           stack: error.stack,
@@ -101,7 +102,7 @@ export function useChatMessages() {
             .single()
         } catch (error) {
           if (error instanceof TypeError) {
-            console.error('Supabase unavailable', {
+            logger.error('Supabase unavailable', {
               name: error.name,
               message: error.message,
               stack: error.stack,
@@ -114,7 +115,7 @@ export function useChatMessages() {
         if (result.error) throw result.error
         return result
       } catch (error) {
-        console.error('sendMessage error', {
+        logger.error('sendMessage error', {
           name: error.name,
           message: error.message,
           stack: error.stack,

--- a/src/hooks/useObjectList.js
+++ b/src/hooks/useObjectList.js
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { supabase } from '@/supabaseClient'
 import { toast } from 'react-hot-toast'
 import { handleSupabaseError } from '@/utils/handleSupabaseError'
+import logger from '@/utils/logger'
 import { exportInventory, importInventory } from '@/utils/exportImport'
 
 const SELECTED_OBJECT_KEY = 'selectedObjectId'
@@ -32,7 +33,7 @@ export function useObjectList() {
           setFetchError('Недостаточно прав')
           return
         }
-        console.error('Ошибка загрузки объектов:', error)
+        logger.error('Ошибка загрузки объектов:', error)
         toast.error('Ошибка загрузки объектов: ' + error.message)
         await handleSupabaseError(error, navigate, 'Ошибка загрузки объектов')
         setFetchError('Ошибка загрузки объектов: ' + error.message)
@@ -41,7 +42,7 @@ export function useObjectList() {
       data = fetchedData
       setObjects(data)
     } catch (err) {
-      console.error('Ошибка загрузки объектов:', err)
+      logger.error('Ошибка загрузки объектов:', err)
       toast.error('Ошибка загрузки объектов: ' + err.message)
       setFetchError('Ошибка загрузки объектов: ' + err.message)
       return


### PR DESCRIPTION
## Summary
- заменить вызовы `console.log`/`console.error` на `logger.info`/`logger.error`
- добавить импорт `logger` в соответствующие файлы

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b001cefa1883249ce3ad6343b110cc