### PR TITLE
feat: draggable object dialog

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -235,7 +235,7 @@ export default function DashboardPage() {
             }
           }}
         >
-          <DialogContent className="relative w-full max-w-md">
+          <DialogContent draggable className="w-full max-w-md">
             <Button
               size="icon"
               className="absolute right-2 top-2"
@@ -243,7 +243,7 @@ export default function DashboardPage() {
             >
               ✕
             </Button>
-            <DialogHeader>
+            <DialogHeader data-dialog-handle>
               <DialogTitle>
                 {editingObject ? 'Редактировать объект' : 'Добавить объект'}
               </DialogTitle>


### PR DESCRIPTION
## Summary
- make DialogContent responsive and draggable on desktop
- enable object editing dialog dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b00988f68c8324888d2e4c4f297732