### PR TITLE
Fix hardware editing form reset and validation

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -36,6 +36,12 @@ import {
 import { Button } from '@/components/ui/button'
 
 const HW_FORM_KEY = (objectId) => `hwForm_${objectId}`
+const DEFAULT_HW_FORM = {
+  name: '',
+  location: '',
+  purchase_status: 'не оплачен',
+  install_status: 'не установлен',
+}
 
 function InventoryTabs({
   selected,
@@ -56,12 +62,6 @@ function InventoryTabs({
   const [messageCount, setMessageCount] = useState(0)
   const [isHWModalOpen, setIsHWModalOpen] = useState(false)
   const [editingHW, setEditingHW] = useState(null)
-  const defaultHWForm = {
-    name: '',
-    location: '',
-    purchase_status: 'не оплачен',
-    install_status: 'не установлен',
-  }
   const hardwareSchema = z.object({
     name: z.string().min(1, 'Введите название'),
     location: z.string().optional(),
@@ -82,7 +82,7 @@ function InventoryTabs({
     formState: { errors },
   } = usePersistedForm(
     selected ? HW_FORM_KEY(selected.id) : null,
-    defaultHWForm,
+    DEFAULT_HW_FORM,
     isHWModalOpen,
     { resolver: zodResolver(hardwareSchema) },
   )
@@ -114,12 +114,7 @@ function InventoryTabs({
   }, [loadedHardware])
 
   const openHWModal = useCallback(() => {
-    reset({
-      name: '',
-      location: '',
-      purchase_status: '�?�� �?���>���ؐ�?',
-      install_status: "�?�� �?�?�'���?�?�?�>��?",
-    })
+    reset(DEFAULT_HW_FORM)
     setEditingHW(null)
     setIsHWModalOpen(true)
   }, [reset])
@@ -136,22 +131,19 @@ function InventoryTabs({
       await createHardware({ ...data, object_id: selected.id })
     }
     setIsHWModalOpen(false)
-    reset({
-      name: '',
-      location: '',
-      purchase_status: '�?�� �?���>���ؐ�?',
-      install_status: "�?�� �?�?�'���?�?�?�>��?",
-    })
+    reset(DEFAULT_HW_FORM)
   })
 
-  const handleEditHW = useCallback(
-    (item) => {
-      reset(item)
-      setEditingHW(item)
-      setIsHWModalOpen(true)
-    },
-    [reset],
-  )
+  const handleEditHW = useCallback((item) => {
+    setEditingHW(item)
+    setIsHWModalOpen(true)
+  }, [])
+
+  useEffect(() => {
+    if (isHWModalOpen && editingHW) {
+      reset(editingHW)
+    }
+  }, [isHWModalOpen, editingHW, reset])
 
   const handleDeleteHW = useCallback(
     async (item) => {

--- a/tests/InventoryTabs.test.jsx
+++ b/tests/InventoryTabs.test.jsx
@@ -8,17 +8,22 @@ var mockLoadHardware,
   mockNavigate,
   mockHardware,
   mockCreateHardware,
-  mockUpdateHardware
+  mockUpdateHardware,
+  mockReset
 
-jest.mock('@/hooks/usePersistedForm.js', () => () => ({
-  register: jest.fn(),
-  handleSubmit: (fn) => fn,
-  reset: jest.fn(),
-  watch: jest.fn((field) =>
-    field === 'purchase_status' ? 'не оплачен' : 'не установлен',
-  ),
-  formState: { errors: {} },
-}))
+jest.mock('@/hooks/usePersistedForm.js', () => () => {
+  mockReset = jest.fn()
+  return {
+    register: jest.fn(),
+    handleSubmit: (fn) => fn,
+    reset: mockReset,
+    setValue: jest.fn(),
+    watch: jest.fn((field) =>
+      field === 'purchase_status' ? 'не оплачен' : 'не установлен',
+    ),
+    formState: { errors: {} },
+  }
+})
 
 jest.mock('@/hooks/useHardware.js', () => {
   mockLoadHardware = jest.fn().mockResolvedValue({ data: [], error: null })
@@ -212,7 +217,8 @@ describe('InventoryTabs', () => {
     await userEvent.click(screen.getByRole('tab', { name: /Железо/ }))
     const editBtn = await screen.findByRole('button', { name: 'Изменить' })
     await userEvent.click(editBtn)
-    expect(screen.getByPlaceholderText('Название')).toBeInTheDocument()
+    await screen.findByPlaceholderText('Название')
+    expect(mockReset).toHaveBeenLastCalledWith(mockHardware[0])
   })
 
   it('скрывает кнопки сохранения описания после сохранения', async () => {


### PR DESCRIPTION
## Summary
- keep hardware edit form populated with existing data
- ensure validation persists until name is entered
- test edit form reset logic

## Testing
- `npm test tests/InventoryTabs.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68b00a63a9188324863c75323d7b506a