### PR TITLE
refactor: map task statuses

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -17,15 +17,23 @@ function formatDate(dateStr) {
   }
 }
 
+const STATUS_LABELS = {
+  planned: 'запланировано',
+  in_progress: 'в работе',
+  done: 'выполнено',
+  canceled: 'отменено',
+}
+
+const STATUS_CLASSES = {
+  planned: 'badge-info',
+  in_progress: 'badge-warning',
+  done: 'badge-success',
+  canceled: 'badge-error',
+}
+
 function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
   const badgeClass = useMemo(
-    () =>
-      ({
-        запланировано: 'badge-info',
-        'в работе': 'badge-warning',
-        выполнено: 'badge-success',
-        отменено: 'badge-error',
-      })[item.status] || 'badge',
+    () => STATUS_CLASSES[item.status] || 'badge',
     [item.status],
   )
 
@@ -75,7 +83,9 @@ function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
         )}
       </CardHeader>
       <CardContent className="flex flex-col xs:flex-row md:flex-row flex-wrap items-center gap-2 mt-2 xs:mt-0">
-        <span className={`badge ${badgeClass}`}>{item.status}</span>
+        <span className={`badge ${badgeClass}`}>
+          {STATUS_LABELS[item.status] || item.status}
+        </span>
         {canManage && (
           <>
             <Button

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -29,6 +29,17 @@ import {
 
 const PAGE_SIZE = 20
 
+const STATUS_MAP = {
+  запланировано: 'planned',
+  'в работе': 'in_progress',
+  выполнено: 'done',
+  отменено: 'canceled',
+}
+
+const REVERSE_STATUS_MAP = Object.fromEntries(
+  Object.entries(STATUS_MAP).map(([k, v]) => [v, k]),
+)
+
 function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const [taskForm, setTaskForm] = useState({
     title: '',
@@ -90,7 +101,11 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const handleTaskSubmit = useCallback(
     async (e) => {
       e.preventDefault()
-      const payload = { ...taskForm, object_id: selected?.id }
+      const payload = {
+        ...taskForm,
+        object_id: selected?.id,
+        status: STATUS_MAP[taskForm.status],
+      }
       try {
         if (editingTask) {
           await updateTask(editingTask.id, payload)
@@ -117,7 +132,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
       title: task.title || '',
       assignee: task.assignee || '',
       due_date: task.due_date || '',
-      status: task.status || 'запланировано',
+      status: REVERSE_STATUS_MAP[task.status] || 'запланировано',
       notes: task.notes || '',
     })
     setEditingTask(task)
@@ -299,7 +314,8 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
               </p>
             )}
             <p>
-              <strong>Статус:</strong> {viewingTask?.status}
+              <strong>Статус:</strong>{' '}
+              {REVERSE_STATUS_MAP[viewingTask?.status] || viewingTask?.status}
             </p>
             {viewingTask?.notes && (
               <p className="whitespace-pre-wrap break-words">

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -9,7 +9,7 @@ import TaskCard from '@/components/TaskCard.jsx'
 const task = {
   id: 't1',
   title: 'Тестовая задача',
-  status: 'запланировано',
+  status: 'planned',
 }
 
 describe('TaskCard', () => {

--- a/tests/TasksTab.test.jsx
+++ b/tests/TasksTab.test.jsx
@@ -74,7 +74,7 @@ describe('TasksTab', () => {
       data: {
         id: 't1',
         title: 'Новая задача',
-        status: 'запланировано',
+        status: 'planned',
         assignee: null,
         due_date: '2024-05-10',
         notes: null,
@@ -107,7 +107,7 @@ describe('TasksTab', () => {
         title: 'Новая задача',
         assignee: 'Иван Петров',
         due_date: '2024-05-10',
-        status: 'запланировано',
+        status: 'planned',
         notes: '',
         object_id: 1,
       })
@@ -118,7 +118,7 @@ describe('TasksTab', () => {
     const task = {
       id: 't1',
       title: 'Существующая задача',
-      status: 'в работе',
+      status: 'in_progress',
       assignee: 'Старый исполнитель',
       due_date: '2024-01-01',
       notes: 'Старые заметки',
@@ -151,7 +151,7 @@ describe('TasksTab', () => {
     await waitFor(() => {
       expect(mockUpdateTask).toHaveBeenCalledWith('t1', {
         title: 'Обновленная задача',
-        status: 'в работе',
+        status: 'in_progress',
         assignee: 'Новый исполнитель',
         due_date: '2024-01-01',
         notes: 'Старые заметки',
@@ -161,7 +161,7 @@ describe('TasksTab', () => {
   })
 
   it('не показывает кнопки редактирования и удаления без прав', () => {
-    const task = { id: 't1', title: 'Задача', status: 'в работе' }
+    const task = { id: 't1', title: 'Задача', status: 'in_progress' }
     mockTasks = [task]
     mockUseAuth.mockReturnValue({
       user: { id: 'u2', email: 'test@example.com' },


### PR DESCRIPTION
## Summary
- map Russian task statuses to database values before saving
- show human-readable labels for database statuses
- update tests for new status mapping

## Testing
- `npm test > /tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b00f9c98a48324b62ba4f3f6251658