### PR TITLE
fix: allow authenticated users manage tasks

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -32,6 +32,7 @@ const STATUS_CLASSES = {
 }
 
 function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
+  const allowManage = Boolean(canManage)
   const badgeClass = useMemo(
     () => STATUS_CLASSES[item.status] || 'badge',
     [item.status],
@@ -86,7 +87,7 @@ function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
         <span className={`badge ${badgeClass}`}>
           {STATUS_LABELS[item.status] || item.status}
         </span>
-        {canManage && (
+        {allowManage && (
           <>
             <Button
               size="sm"

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -63,8 +63,8 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
     deleteTask,
   } = useTasks(selected?.id)
 
-  const { isAdmin, isManager } = useAuth()
-  const canManage = isAdmin || isManager
+  const { user } = useAuth()
+  const canManage = Boolean(user)
 
   useEffect(() => {
     if (selected?.id) {


### PR DESCRIPTION
## Summary
- allow any authenticated user to edit or delete tasks
- ensure TaskCard respects canManage flag for edit controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09d736cdc83249de8e1fe8ed95ef4