### PR TITLE
Уточнены статусы задач

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { Button } from '@/components/ui/button'
+import { REVERSE_STATUS_MAP } from '@/constants/taskStatus'
 
 /**
  * Format date string into locale friendly format.
@@ -15,13 +16,6 @@ function formatDate(dateStr) {
   } catch {
     return dateStr
   }
-}
-
-const STATUS_LABELS = {
-  planned: 'запланировано',
-  in_progress: 'в работе',
-  done: 'выполнено',
-  canceled: 'отменено',
 }
 
 const STATUS_CLASSES = {
@@ -84,7 +78,7 @@ function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
       </CardHeader>
       <CardContent className="flex flex-col xs:flex-row md:flex-row flex-wrap items-center gap-2 mt-2 xs:mt-0">
         <span className={`badge ${badgeClass}`}>
-          {STATUS_LABELS[item.status] || item.status}
+          {REVERSE_STATUS_MAP[item.status] || item.status}
         </span>
         {canManage && (
           <>

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -7,6 +7,7 @@ import ConfirmModal from './ConfirmModal'
 import { useTasks } from '@/hooks/useTasks'
 import { useAuth } from '@/hooks/useAuth'
 import logger from '@/utils/logger'
+import { STATUS_MAP, REVERSE_STATUS_MAP } from '@/constants/taskStatus'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -29,16 +30,7 @@ import {
 
 const PAGE_SIZE = 20
 
-const STATUS_MAP = {
-  запланировано: 'planned',
-  'в работе': 'in_progress',
-  выполнено: 'done',
-  отменено: 'canceled',
-}
-
-const REVERSE_STATUS_MAP = Object.fromEntries(
-  Object.entries(STATUS_MAP).map(([k, v]) => [v, k]),
-)
+const STATUS_OPTIONS = Object.keys(STATUS_MAP)
 
 function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const [taskForm, setTaskForm] = useState({
@@ -101,10 +93,15 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const handleTaskSubmit = useCallback(
     async (e) => {
       e.preventDefault()
+      const statusValue = STATUS_MAP[taskForm.status]
+      if (!statusValue) {
+        logger.error('Unknown status selected:', taskForm.status)
+        return
+      }
       const payload = {
         ...taskForm,
         object_id: selected?.id,
-        status: STATUS_MAP[taskForm.status],
+        status: statusValue,
       }
       try {
         if (editingTask) {
@@ -263,10 +260,11 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
                   <SelectValue placeholder="Выберите статус" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="запланировано">запланировано</SelectItem>
-                  <SelectItem value="в работе">в работе</SelectItem>
-                  <SelectItem value="выполнено">выполнено</SelectItem>
-                  <SelectItem value="отменено">отменено</SelectItem>
+                  {STATUS_OPTIONS.map((status) => (
+                    <SelectItem key={status} value={status}>
+                      {status}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/src/constants/taskStatus.js
+++ b/src/constants/taskStatus.js
@@ -1,0 +1,10 @@
+export const STATUS_MAP = {
+  запланировано: 'planned',
+  'в работе': 'in_progress',
+  выполнено: 'done',
+  отменено: 'canceled',
+}
+
+export const REVERSE_STATUS_MAP = Object.fromEntries(
+  Object.entries(STATUS_MAP).map(([k, v]) => [v, k]),
+)

--- a/supabase/migrations/20250901000000_add-task-status-check.sql
+++ b/supabase/migrations/20250901000000_add-task-status-check.sql
@@ -1,0 +1,4 @@
+alter table tasks drop constraint if exists tasks_status_check;
+alter table tasks
+  add constraint tasks_status_check
+  check (status in ('planned','in_progress','done','canceled'));


### PR DESCRIPTION
## Summary
- ограничен список допустимых статусов задач на уровне БД
- вынесены константы статусов и их отображения
- карточки задач и вкладка задач используют единые статусы

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09d7175108324b14ac064fac2b7ea