### PR TITLE
validate task status before creation

### DIFF
--- a/src/constants/taskStatus.js
+++ b/src/constants/taskStatus.js
@@ -1,3 +1,5 @@
+export const TASK_STATUSES = ['planned', 'in_progress', 'done', 'canceled']
+
 export const STATUS_MAP = {
   запланировано: 'planned',
   'в работе': 'in_progress',

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -3,6 +3,7 @@ import { supabase } from '@/supabaseClient'
 import { handleSupabaseError } from '@/utils/handleSupabaseError'
 import { useNavigate } from 'react-router-dom'
 import logger from '@/utils/logger'
+import { TASK_STATUSES } from '@/constants/taskStatus'
 
 export function useTasks(objectId) {
   const navigate = useNavigate()
@@ -65,6 +66,9 @@ export function useTasks(objectId) {
   const insertTask = useCallback(
     async (data) => {
       try {
+        if (!TASK_STATUSES.includes(data.status)) {
+          throw new Error('Недопустимый статус задачи')
+        }
         const fieldsWithDueDate =
           'id, title, status, assignee, due_date, notes, created_at'
         const fieldsWithoutDueDate =
@@ -109,7 +113,11 @@ export function useTasks(objectId) {
         if (result.error) throw result.error
         return result
       } catch (err) {
-        await handleSupabaseError(err, navigate, 'Ошибка добавления задачи')
+        await handleSupabaseError(
+          err,
+          navigate,
+          err.message || 'Ошибка добавления задачи',
+        )
         return { data: null, error: err }
       }
     },

--- a/tests/useTasks.test.js
+++ b/tests/useTasks.test.js
@@ -50,6 +50,22 @@ describe('useTasks', () => {
     )
   })
 
+  it('возвращает ошибку при недопустимом статусе', async () => {
+    const { result } = renderHook(() => useTasks())
+    const { error } = await result.current.createTask({
+      title: 't',
+      status: 'unknown',
+    })
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe('Недопустимый статус задачи')
+    expect(mockHandleSupabaseError).toHaveBeenCalledWith(
+      error,
+      expect.any(Function),
+      'Недопустимый статус задачи',
+    )
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
   it('успешно загружает задачи при ошибке schema cache', async () => {
     mockRangeOrder
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- add TASK_STATUSES constant with allowed values
- validate task status before sending create request
- test invalid status handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b14d2320dc83248fe30b0c4d3a3541