### PR TITLE
feat: improve calendar indicator for dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -103,6 +103,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  .dark input[type='date']::-webkit-calendar-picker-indicator {
+    filter: invert(1) brightness(1.2);
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- add CSS filter for date input calendar indicator in dark mode

## Testing
- `npx jest --config jest.config.js --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_68b151c5c81883248d224fd5684f9880