### PR TITLE
feat: retry due date column for tasks

### DIFF
--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -55,8 +55,8 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
     deleteTask,
   } = useTasks(selected?.id)
 
-  const { user } = useAuth()
-  const canManage = Boolean(user)
+  const { isAdmin, isManager } = useAuth()
+  const canManage = isAdmin || isManager
 
   useEffect(() => {
     if (selected?.id) {


### PR DESCRIPTION
## Summary
- always try selecting `due_date` when querying or mutating tasks
- allow only admins and managers to manage tasks

## Testing
- `npm test tests/TasksTab.test.jsx tests/useTasks.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b151c409f08324a4845610d0c07c41