### PR TITLE
refactor: remove role checks from task components

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -25,8 +25,7 @@ const STATUS_CLASSES = {
   canceled: 'badge-error',
 }
 
-function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
-  const allowManage = Boolean(canManage)
+function TaskCard({ item, onEdit, onDelete, onView }) {
   const badgeClass = useMemo(
     () => STATUS_CLASSES[item.status] || 'badge',
     [item.status],
@@ -81,30 +80,26 @@ function TaskCard({ item, onEdit, onDelete, onView, canManage = false }) {
         <span className={`badge ${badgeClass}`}>
           {REVERSE_STATUS_MAP[item.status] || item.status}
         </span>
-        {allowManage && (
-          <>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="w-full xs:w-auto"
-              title="Редактировать"
-              aria-label="Редактировать задачу"
-              onClick={handleEdit}
-            >
-              <PencilIcon className="w-4 h-4" />
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="w-full xs:w-auto"
-              title="Удалить"
-              aria-label="Удалить задачу"
-              onClick={handleDelete}
-            >
-              <TrashIcon className="w-4 h-4" />
-            </Button>
-          </>
-        )}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full xs:w-auto"
+          title="Редактировать"
+          aria-label="Редактировать задачу"
+          onClick={handleEdit}
+        >
+          <PencilIcon className="w-4 h-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full xs:w-auto"
+          title="Удалить"
+          aria-label="Удалить задачу"
+          onClick={handleDelete}
+        >
+          <TrashIcon className="w-4 h-4" />
+        </Button>
       </CardContent>
     </Card>
   )
@@ -122,5 +117,4 @@ TaskCard.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   onView: PropTypes.func.isRequired,
-  canManage: PropTypes.bool,
 }

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -5,7 +5,6 @@ import TaskCard from './TaskCard'
 import ErrorMessage from './ErrorMessage'
 import ConfirmModal from './ConfirmModal'
 import { useTasks } from '@/hooks/useTasks'
-import { useAuth } from '@/hooks/useAuth'
 import logger from '@/utils/logger'
 import { STATUS_MAP, REVERSE_STATUS_MAP } from '@/constants/taskStatus'
 
@@ -54,9 +53,6 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
     updateTask,
     deleteTask,
   } = useTasks(selected?.id)
-
-  const { isAdmin, isManager } = useAuth()
-  const canManage = isAdmin || isManager
 
   useEffect(() => {
     if (selected?.id) {
@@ -198,7 +194,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
               onEdit={() => handleEditTask(task)}
               onDelete={() => setTaskDeleteId(task.id)}
               onView={() => setViewingTask(task)}
-              canManage={canManage}
+              canManage={true}
             />
           ))}
         </div>

--- a/tests/TasksTab.test.jsx
+++ b/tests/TasksTab.test.jsx
@@ -8,7 +8,6 @@ var mockTasks = [],
   mockCreateTask,
   mockUpdateTask
 const mockNavigate = jest.fn()
-const mockUseAuth = jest.fn()
 
 jest.mock('@/hooks/useTasks.js', () => {
   mockTasks = []
@@ -29,10 +28,6 @@ jest.mock('@/hooks/useTasks.js', () => {
   }
 })
 
-jest.mock('@/hooks/useAuth.js', () => ({
-  useAuth: () => mockUseAuth(),
-}))
-
 jest.mock('react-hot-toast', () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }))
@@ -51,11 +46,6 @@ describe('TasksTab', () => {
     mockCreateTask.mockResolvedValue({ data: null, error: null })
     mockUpdateTask.mockResolvedValue({ data: null, error: null })
     jest.clearAllMocks()
-    mockUseAuth.mockReturnValue({
-      user: { id: 'u1', email: 'me@example.com' },
-      isAdmin: true,
-      isManager: false,
-    })
   })
 
   it('показывает сообщение при отсутствии задач', async () => {
@@ -158,26 +148,5 @@ describe('TasksTab', () => {
         object_id: 1,
       })
     })
-  })
-
-  it('не показывает кнопки редактирования и удаления без прав', () => {
-    const task = { id: 't1', title: 'Задача', status: 'in_progress' }
-    mockTasks = [task]
-    mockUseAuth.mockReturnValue({
-      user: { id: 'u2', email: 'test@example.com' },
-      isAdmin: false,
-      isManager: false,
-    })
-
-    render(
-      <MemoryRouter>
-        <TasksTab selected={selected} />
-      </MemoryRouter>,
-    )
-
-    expect(
-      screen.queryByLabelText('Редактировать задачу'),
-    ).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Удалить задачу')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- drop auth-based management check in TasksTab and TaskCard
- always show task management buttons
- update tests after removing role logic

## Testing
- `npx jest tests/TasksTab.test.jsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b155955ce883249da93c021045265a