### PR TITLE
fix: remove missing border-border utility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,7 @@
   }
 
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
 
   body {


### PR DESCRIPTION
## Summary
- replace @apply border-border with explicit border-color declaration

## Testing
- `npm run build`
- `CI=true npm test -- --silent` *(fails: TaskCard › не показывает кнопки без прав)*

------
https://chatgpt.com/codex/tasks/task_e_68b16a54ee688324b736881cb48bd51c