### PR TITLE
fix: clear timer in withTimeout utility

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -4,12 +4,13 @@ import { apiBaseUrl, isApiConfigured } from '@/apiConfig'
 const DEFAULT_TIMEOUT = 10000
 
 function withTimeout(promise, timeout = DEFAULT_TIMEOUT) {
+  let timer
   return Promise.race([
     promise,
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('Request timed out')), timeout),
-    ),
-  ])
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error('Request timed out')), timeout)
+    }),
+  ]).finally(() => clearTimeout(timer))
 }
 
 function formatError(error) {


### PR DESCRIPTION
## Summary
- clear timeout timer in `withTimeout`

## Testing
- `npm test`
- `CI=true npm test tests/logger.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b293920a5083249d9efa614145a9cc