### PR TITLE
Мемоизация объекта value в AuthContext

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useState, useMemo } from 'react'
 import { toast } from 'react-hot-toast'
 import { supabase, isSupabaseConfigured } from '@/supabaseClient'
 import { isApiConfigured } from '@/apiConfig'
@@ -75,11 +75,14 @@ export function AuthProvider({ children }) {
     return () => subscription.unsubscribe()
   }, [])
 
-  const value = {
-    user,
-    role,
-    isLoading,
-  }
+  const value = useMemo(
+    () => ({
+      user,
+      role,
+      isLoading,
+    }),
+    [user, role, isLoading],
+  )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }


### PR DESCRIPTION
## Summary
- использовать `useMemo` для `value` в `AuthContext`

## Testing
- `npm test -- --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b29390a61083249c585b69ba68f226