### PR TITLE
fix duplicated withTimeout

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -17,14 +17,6 @@ function withTimeout(operation, timeout = DEFAULT_TIMEOUT) {
       clearTimeout(timer)
     },
   )
-function withTimeout(promise, timeout = DEFAULT_TIMEOUT) {
-  let timer
-  return Promise.race([
-    promise,
-    new Promise((_, reject) => {
-      timer = setTimeout(() => reject(new Error('Request timed out')), timeout)
-    }),
-  ]).finally(() => clearTimeout(timer))
 }
 
 function formatError(error) {


### PR DESCRIPTION
## Summary
- close first withTimeout function and remove duplicate definition

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8c4f4c483248d22c4befa38ba35