### PR TITLE
fix: improve hardware card status layout

### DIFF
--- a/src/components/HardwareCard.jsx
+++ b/src/components/HardwareCard.jsx
@@ -13,7 +13,7 @@ export default function HardwareCard({ item, onEdit, onDelete, user = null }) {
         <div className="text-sm text-foreground/70">{item.location}</div>
       </CardHeader>
       <CardContent className="flex justify-between items-center">
-        <div className="flex space-x-2 mt-1 text-sm">
+        <div className="flex flex-col sm:flex-row space-y-1 sm:space-y-0 sm:space-x-2 text-sm max-sm:text-xs">
           <span>Статус покупки: {item.purchase_status}</span>
           <span>Статус установки: {item.install_status}</span>
         </div>


### PR DESCRIPTION
## Summary
- use vertical layout for status info on small screens
- reduce font size of status info on narrow devices

## Testing
- `npm test` *(fails: useTasks.test.js, ObjectList.test.jsx, InventoryTabs.test.jsx, TasksTab.test.jsx, AuthPage.test.jsx, MissingEnvPage.test.jsx, ErrorBoundary.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b571a92db88324a4a0e0c409aef839