### PR TITLE
feat: improve inventory tabs overflow handling

### DIFF
--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -188,11 +188,22 @@ function InventoryTabs({
 
   return (
     <Tabs value={tab} onValueChange={setTab} className="flex flex-col h-full">
-      <TabsList className="mb-4">
-        <TabsTrigger value="desc">Описание</TabsTrigger>
-        <TabsTrigger value="hw">Железо ({hardware.length})</TabsTrigger>
-        <TabsTrigger value="tasks">Задачи ({tasksCount})</TabsTrigger>
-        <TabsTrigger value="chat">Чат ({messageCount})</TabsTrigger>
+      <TabsList
+        className="mb-4 overflow-x-auto flex-nowrap"
+        style={{ WebkitOverflowScrolling: "touch" }}
+      >
+        <TabsTrigger value="desc" className="flex-shrink-0">
+          Описание
+        </TabsTrigger>
+        <TabsTrigger value="hw" className="flex-shrink-0">
+          Железо ({hardware.length})
+        </TabsTrigger>
+        <TabsTrigger value="tasks" className="flex-shrink-0">
+          Задачи ({tasksCount})
+        </TabsTrigger>
+        <TabsTrigger value="chat" className="flex-shrink-0">
+          Чат ({messageCount})
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="desc" className="flex-1 overflow-auto">


### PR DESCRIPTION
## Summary
- prevent tab shrinking by adding flex-shrink-0 to Tab triggers
- enable horizontal scroll on InventoryTabs

## Testing
- `npm test` *(fails: MissingEnvPage.test, InventoryTabs.test, TasksTab.test and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b571a0fc8483248eb637327110709f