### PR TITLE
feat: lock body scroll when sidebar open

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -78,6 +78,18 @@ export default function DashboardPage() {
 
   const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
 
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    if (isSidebarOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = originalOverflow;
+    }
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isSidebarOpen]);
+
   const onSelect = (obj) => {
     handleSelect(obj);
     clearNotifications(obj.id);
@@ -267,12 +279,16 @@ export default function DashboardPage() {
           />
         </aside>
         {isSidebarOpen && (
-          <div className="fixed inset-0 z-10 flex">
+          <div
+            className="fixed inset-0 z-10 flex"
+            aria-modal="true"
+            role="dialog"
+          >
             <div
               className="fixed inset-0 bg-background"
               onClick={toggleSidebar}
             />
-            <aside className="relative z-20 w-72 bg-muted p-4 shadow-lg overflow-y-auto">
+            <aside className="relative z-20 w-72 bg-muted p-4 shadow-lg overflow-y-auto transition-transform">
               <Button
                 size="icon"
                 className="absolute right-2 top-2"


### PR DESCRIPTION
## Summary
- lock body scroll when mobile sidebar is open
- improve overlay accessibility and add transition class

## Testing
- `CI=true npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b571a83c608324aff031ce81456f4d