### PR TITLE
fix: align reset button in task filters

### DIFF
--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -210,7 +210,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
         </div>
         <div className="w-full sm:min-w-[220px] sm:w-auto flex-1">
           <Label>{t("tasks.assignee")}</Label>
-          <div className="relative">
+          <div className="relative h-10">
             <Input
               ref={assigneeInputRef}
               value={filterAssignee}
@@ -219,7 +219,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
               onKeyDown={(e) => {
                 if (e.key === "Enter") e.preventDefault();
               }}
-              className="pr-10"
+              className="h-full pr-10"
             />
             {(filterStatus !== "all" || filterAssignee) && (
               <Button


### PR DESCRIPTION
## Summary
- ensure filter assignee container has fixed height and relative positioning
- keep reset button anchored to the right side

## Testing
- `npm test` *(fails: useTasks.test.js, SignupPending.test.jsx, MissingEnvPage.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b59e9cc26c8324a7abc8d984c499b9