### PR TITLE
feat: improve view task modal styling

### DIFF
--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -357,11 +357,15 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
         open={!!viewingTask}
         onOpenChange={(open) => !open && setViewingTask(null)}
       >
-        <DialogContent className="border">
+        <DialogContent
+          aria-labelledby="view-task-title"
+          aria-describedby="view-task-content"
+          className="border rounded-md bg-background shadow-lg"
+        >
           <DialogHeader>
-            <DialogTitle>{viewingTask?.title}</DialogTitle>
+            <DialogTitle id="view-task-title">{viewingTask?.title}</DialogTitle>
           </DialogHeader>
-          <div className="space-y-2">
+          <div id="view-task-content" className="space-y-2">
             {viewingTask?.assignee && (
               <p>
                 <strong>{t("tasks.view.assignee")}</strong>{" "}


### PR DESCRIPTION
## Summary
- style "View Task" modal with border, rounded corners and shadow
- add ARIA references for modal content

## Testing
- `npm test` *(fails: useTasks.test.js, ObjectList.test.jsx, InventoryTabs.test.jsx, TaskCard.test.jsx, ErrorBoundary.test.jsx, MissingEnvPage.test.jsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b59e973208832488c68d7371ed9460