### PR TITLE
Выравнивание элементов TaskCard и Storybook пример

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -83,14 +83,14 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
           )}
         </p>
       </CardHeader>
-      <CardContent className="flex flex-col sm:flex-row items-center gap-2 sm:gap-3 mt-2 sm:mt-0 sm:whitespace-nowrap">
+      <CardContent className="flex flex-col sm:flex-row items-center justify-evenly w-full sm:w-auto gap-2 sm:gap-3 mt-2 sm:mt-0 sm:whitespace-nowrap">
         <Badge variant={badgeVariant}>
           {REVERSE_STATUS_MAP[item.status] || item.status}
         </Badge>
         <Button
           size="iconSm"
           variant="ghost"
-          className="text-blue-600 dark:text-blue-400"
+          className="flex items-center justify-center text-blue-600 dark:text-blue-400"
           title={t("common.edit")}
           aria-label={t("common.edit")}
           onClick={handleEdit}
@@ -100,7 +100,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
         <Button
           size="iconSm"
           variant="ghost"
-          className="text-red-600 dark:text-red-400"
+          className="flex items-center justify-center text-red-600 dark:text-red-400"
           title={t("common.delete")}
           aria-label={t("common.delete")}
           onClick={handleDelete}

--- a/src/components/TaskCard.stories.jsx
+++ b/src/components/TaskCard.stories.jsx
@@ -1,0 +1,44 @@
+import TaskCard from "./TaskCard.jsx";
+
+export default {
+  title: "Components/TaskCard",
+  component: TaskCard,
+};
+
+const sampleItem = {
+  title: "Пример задачи",
+  status: "planned",
+  assignee: "Иван",
+  due_date: "2024-12-31",
+  created_at: "2024-01-01",
+};
+
+const Template = (props) => <TaskCard {...props} />;
+
+export const Mobile = {
+  render: (args) => (
+    <div className="w-80">
+      <Template {...args} />
+    </div>
+  ),
+  args: {
+    item: sampleItem,
+    onEdit: () => {},
+    onDelete: () => {},
+    onView: () => {},
+  },
+};
+
+export const Desktop = {
+  render: (args) => (
+    <div className="w-[700px]">
+      <Template {...args} />
+    </div>
+  ),
+  args: {
+    item: sampleItem,
+    onEdit: () => {},
+    onDelete: () => {},
+    onView: () => {},
+  },
+};


### PR DESCRIPTION
## Summary
- центрировал элементы статуса и кнопок в TaskCard
- добавил Storybook-пример TaskCard для разных размеров

## Testing
- `npm test` *(падает: MissingEnvPage, useTasks и др.)*

------
https://chatgpt.com/codex/tasks/task_e_68b59e90ce0c83249586e88bd3f5144a