### PR TITLE
refactor: simplify task statuses and add translations

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,11 +1,10 @@
-﻿import { memo, useCallback } from "react";
+import { memo, useCallback } from "react";
 import PropTypes from "prop-types";
 import { formatDate } from "@/utils/date";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { REVERSE_STATUS_MAP } from "@/constants/taskStatus";
 import { t } from "@/i18n";
 
 const STATUS_VARIANTS = {
@@ -55,13 +54,11 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
           {item.title}
         </CardTitle>
         <p className="text-sm text-foreground/70 hidden">
-          {assignee && <span>РСЃРїРѕР»РЅРёС‚РµР»СЊ: {assignee}</span>}
+          {assignee && <span>Исполнитель: {assignee}</span>}
           {assignee && (assignedAt || dueDate) && <span> | </span>}
-          {assignedAt && (
-            <span>РќР°Р·РЅР°С‡РµРЅР°: {formatDate(assignedAt)}</span>
-          )}
+          {assignedAt && <span>Назначена: {formatDate(assignedAt)}</span>}
           {dueDate && (assignedAt || assignee) && <span> | </span>}
-          {dueDate && <span>РЎСЂРѕРє РґРѕ: {formatDate(dueDate)}</span>}
+          {dueDate && <span>Срок до: {formatDate(dueDate)}</span>}
         </p>
         <p className="text-sm text-foreground/70">
           {assignee && (
@@ -85,7 +82,7 @@ function TaskCard({ item, onEdit, onDelete, onView }) {
       </CardHeader>
       <CardContent className="flex flex-col sm:flex-row items-center justify-evenly w-full sm:w-auto gap-2 sm:gap-3 mt-2 sm:mt-0 sm:whitespace-nowrap">
         <Badge variant={badgeVariant}>
-          {REVERSE_STATUS_MAP[item.status] || item.status}
+          {t(`tasks.statuses.${item.status}`)}
         </Badge>
         <Button
           size="iconSm"

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -6,7 +6,7 @@ import ErrorMessage from "./ErrorMessage";
 import ConfirmModal from "./ConfirmModal";
 import { useTasks } from "@/hooks/useTasks";
 import logger from "@/utils/logger";
-import { STATUS_MAP, REVERSE_STATUS_MAP } from "@/constants/taskStatus";
+import { TASK_STATUSES } from "@/constants/taskStatus";
 import { formatDate } from "@/utils/date";
 import { t } from "@/i18n";
 
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/select";
 
 const PAGE_SIZE = 20;
-const STATUS_OPTIONS = Object.keys(STATUS_MAP);
+const STATUS_OPTIONS = TASK_STATUSES;
 
 function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const assigneeInputRef = useRef(null);
@@ -62,8 +62,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
 
   useEffect(() => {
     if (!selected?.id) return;
-    const statusCode =
-      filterStatus === "all" ? undefined : STATUS_MAP[filterStatus];
+    const statusCode = filterStatus === "all" ? undefined : filterStatus;
     const assignee = filterAssignee.trim() || undefined;
     loadTasks({ limit: PAGE_SIZE, status: statusCode, assignee });
   }, [selected?.id, filterStatus, filterAssignee, loadTasks]);
@@ -106,15 +105,14 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
   const handleTaskSubmit = useCallback(
     async (e) => {
       e.preventDefault();
-      const statusValue = STATUS_MAP[taskForm.status];
-      if (!statusValue) {
+      if (!TASK_STATUSES.includes(taskForm.status)) {
         logger.error("Unknown status selected:", taskForm.status);
         return;
       }
       const payload = {
         ...taskForm,
         object_id: selected?.id,
-        status: statusValue,
+        status: taskForm.status,
       };
       try {
         if (editingTask) await updateTask(editingTask.id, payload);
@@ -139,7 +137,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
       title: task.title || "",
       assignee: task.assignee || "",
       due_date: task.due_date || "",
-      status: REVERSE_STATUS_MAP[task.status] || STATUS_OPTIONS[0] || "",
+      status: task.status || STATUS_OPTIONS[0] || "",
       notes: task.notes || "",
     });
     setEditingTask(task);
@@ -205,7 +203,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
               <SelectItem value="all">{t("common.all")}</SelectItem>
               {STATUS_OPTIONS.map((status) => (
                 <SelectItem key={status} value={status}>
-                  {status}
+                  {t(`tasks.statuses.${status}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -328,7 +326,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
                 <SelectContent>
                   {STATUS_OPTIONS.map((status) => (
                     <SelectItem key={status} value={status}>
-                      {status}
+                      {t(`tasks.statuses.${status}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -389,7 +387,7 @@ function TasksTab({ selected, registerAddHandler, onCountChange }) {
             )}
             <p>
               <strong>{t("tasks.view.status")}</strong>{" "}
-              {REVERSE_STATUS_MAP[viewingTask?.status] || viewingTask?.status}
+              {t(`tasks.statuses.${viewingTask?.status}`)}
             </p>
             {viewingTask?.notes && (
               <p className="whitespace-pre-wrap break-words">

--- a/src/constants/taskStatus.js
+++ b/src/constants/taskStatus.js
@@ -1,17 +1,1 @@
-﻿export const TASK_STATUSES = ["planned", "in_progress", "done", "canceled"];
-
-// RU label -> internal code
-export const STATUS_MAP = {
-  Запланирована: "planned",
-  "В работе": "in_progress",
-  Выполнена: "done",
-  Отменена: "canceled",
-};
-
-// internal code -> RU label
-export const REVERSE_STATUS_MAP = {
-  planned: "Запланирована",
-  in_progress: "В работе",
-  done: "Выполнена",
-  canceled: "Отменена",
-};
+export const TASK_STATUSES = ["planned", "in_progress", "done", "canceled"];

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -37,6 +37,12 @@ export const ru = {
       "\u0423\u0434\u0430\u043b\u0438\u0442\u044c \u043e\u0431\u044a\u0435\u043a\u0442",
   },
   tasks: {
+    statuses: {
+      planned: "Запланирована",
+      in_progress: "В работе",
+      done: "Выполнена",
+      canceled: "Отменена",
+    },
     headerPrefix: "\u0417\u0430\u0434\u0430\u0447\u0438 \u0434\u043b\u044f",
     add: "\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0443",
     empty:


### PR DESCRIPTION
## Summary
- remove STATUS_MAP/REVERSE_STATUS_MAP in favor of TASK_STATUSES
- add Russian translations for task statuses
- use i18n strings for displaying task status

## Testing
- `npm test` *(fails: FAIL src/components/__tests__/ObjectList.test.jsx, FAIL tests/MissingEnvPage.test.jsx, and others)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5af55b0dc83248e42c5ef60fa45e4