### PR TITLE
chore: adjust imagemin presets and enable cache

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,9 +18,10 @@ export default defineConfig(({ mode }) => {
       ...(isProd
         ? [
             viteImagemin({
+              cache: true,
               plugins: {
-                jpg: imageminMozjpeg(),
-                png: imageminPngquant(),
+                jpg: imageminMozjpeg({ quality: 80 }),
+                png: imageminPngquant({ quality: [0.65, 0.8] }),
               },
             }),
             viteCompression(),


### PR DESCRIPTION
## Summary
- use mozjpeg/pngquant with less aggressive quality
- enable caching for vite-plugin-imagemin to speed up local builds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba11b6f08324a3ffe482a3eb8e79