### PR TITLE
feat: optimize route loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="%VITE_SUPABASE_URL%" />
+    <link rel="modulepreload" href="/src/pages/DashboardPage.jsx" />
     <title>Inventory App</title>
   </head>
   <body class="w-full min-h-screen bg-background text-foreground duration-300">

--- a/src/components/InventoryTabs.jsx
+++ b/src/components/InventoryTabs.jsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, Suspense, lazy } from "react";
 import PropTypes from "prop-types";
 
 import usePersistedForm from "@/hooks/usePersistedForm";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import HardwareCard from "./HardwareCard";
-import ChatTab from "./ChatTab";
-import TasksTab from "./TasksTab";
+const ChatTab = lazy(() => import("./ChatTab"));
+const TasksTab = lazy(() => import("./TasksTab"));
 import { PlusIcon } from "@heroicons/react/24/outline";
 import { linkifyText } from "@/utils/linkify";
 import { useHardware } from "@/hooks/useHardware";
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/dialog";
 
 import { Button } from "@/components/ui/button";
+import Spinner from "./Spinner";
 
 const HW_FORM_KEY = (objectId) => `hwForm_${objectId}`;
 const DEFAULT_HW_FORM = {
@@ -284,21 +285,25 @@ function InventoryTabs({
 
       <TabsContent value="tasks" className="flex-1 overflow-auto">
         {tab === "tasks" ? (
-          <TasksTab
-            selected={selected}
-            registerAddHandler={registerAddHandler}
-            onCountChange={setTasksCount}
-          />
+          <Suspense fallback={<Spinner />}>
+            <TasksTab
+              selected={selected}
+              registerAddHandler={registerAddHandler}
+              onCountChange={setTasksCount}
+            />
+          </Suspense>
         ) : null}
       </TabsContent>
       <TabsContent value="chat" className="flex-1 overflow-auto">
         {tab === "chat" ? (
-          <ChatTab
-            selected={selected}
-            userEmail={user?.email}
-            active={tab === "chat"}
-            onCountChange={setMessageCount}
-          />
+          <Suspense fallback={<Spinner />}>
+            <ChatTab
+              selected={selected}
+              userEmail={user?.email}
+              active={tab === "chat"}
+              onCountChange={setMessageCount}
+            />
+          </Suspense>
         ) : null}
       </TabsContent>
 

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,8 +1,16 @@
-import React, { useState, useRef, useCallback, useEffect } from "react";
-import InventorySidebar from "@/components/InventorySidebar";
-import InventoryTabs from "@/components/InventoryTabs";
-import AccountModal from "@/components/AccountModal";
-import ConfirmModal from "@/components/ConfirmModal";
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  Suspense,
+  lazy,
+} from "react";
+import Spinner from "@/components/Spinner";
+const InventorySidebar = lazy(() => import("@/components/InventorySidebar"));
+const InventoryTabs = lazy(() => import("@/components/InventoryTabs"));
+const AccountModal = lazy(() => import("@/components/AccountModal"));
+const ConfirmModal = lazy(() => import("@/components/ConfirmModal"));
 import {
   PlusIcon,
   TrashIcon,
@@ -309,14 +317,16 @@ export default function DashboardPage() {
     <>
       <div className="flex min-h-screen bg-background">
         <aside className="hidden md:flex flex-col w-72 bg-muted p-4 border-r shadow-lg overflow-y-auto">
-          <InventorySidebar
-            objects={objects}
-            selected={selected}
-            onSelect={onSelect}
-            onEdit={openEditModal}
-            onDelete={setDeleteCandidate}
-            notifications={chatUnread}
-          />
+          <Suspense fallback={<Spinner />}>
+            <InventorySidebar
+              objects={objects}
+              selected={selected}
+              onSelect={onSelect}
+              onEdit={openEditModal}
+              onDelete={setDeleteCandidate}
+              notifications={chatUnread}
+            />
+          </Suspense>
         </aside>
         {isSidebarOpen && (
           <div
@@ -338,14 +348,16 @@ export default function DashboardPage() {
               >
                 <XMarkIcon className="w-5 h-5" />
               </Button>
-              <InventorySidebar
-                objects={objects}
-                selected={selected}
-                onSelect={onSelect}
-                onEdit={openEditModal}
-                onDelete={setDeleteCandidate}
-                notifications={chatUnread}
-              />
+              <Suspense fallback={<Spinner />}>
+                <InventorySidebar
+                  objects={objects}
+                  selected={selected}
+                  onSelect={onSelect}
+                  onEdit={openEditModal}
+                  onDelete={setDeleteCandidate}
+                  notifications={chatUnread}
+                />
+              </Suspense>
             </aside>
           </div>
         )}
@@ -450,14 +462,16 @@ export default function DashboardPage() {
           </header>
 
           <div className="flex-1 overflow-auto p-2 sm:p-4">
-            <InventoryTabs
-              selected={selected}
-              onUpdateSelected={onUpdateSelected}
-              onTabChange={onTabChange}
-              registerAddHandler={registerAddHandler}
-              tasksCount={tasksCount}
-              chatCount={chatCount}
-            />
+            <Suspense fallback={<Spinner />}>
+              <InventoryTabs
+                selected={selected}
+                onUpdateSelected={onUpdateSelected}
+                onTabChange={onTabChange}
+                registerAddHandler={registerAddHandler}
+                tasksCount={tasksCount}
+                chatCount={chatCount}
+              />
+            </Suspense>
           </div>
         </div>
 
@@ -502,24 +516,28 @@ export default function DashboardPage() {
           </DialogContent>
         </Dialog>
 
-        <ConfirmModal
-          open={!!deleteCandidate}
-          title={t("objects.confirmDeleteTitle")}
-          confirmLabel={
-            <>
-              <TrashIcon className="w-4 h-4" /> {t("common.delete")}
-            </>
-          }
-          onConfirm={onConfirmDelete}
-          onCancel={() => setDeleteCandidate(null)}
-        />
+        <Suspense fallback={<Spinner />}>
+          <ConfirmModal
+            open={!!deleteCandidate}
+            title={t("objects.confirmDeleteTitle")}
+            confirmLabel={
+              <>
+                <TrashIcon className="w-4 h-4" /> {t("common.delete")}
+              </>
+            }
+            onConfirm={onConfirmDelete}
+            onCancel={() => setDeleteCandidate(null)}
+          />
+        </Suspense>
 
         {isAccountModalOpen && (
-          <AccountModal
-            user={user}
-            onClose={() => setIsAccountModalOpen(false)}
-            onUpdated={() => {}}
-          />
+          <Suspense fallback={<Spinner />}>
+            <AccountModal
+              user={user}
+              onClose={() => setIsAccountModalOpen(false)}
+              onUpdated={() => {}}
+            />
+          </Suspense>
         )}
       </div>
     </>


### PR DESCRIPTION
## Summary
- lazy load dashboard components and tabs
- preload hot dashboard route module
- add suspense fallbacks

## Testing
- `npm test` *(fails: see logs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2272fb083249979d1042e866f4d