### PR TITLE
Унификация PropTypes и устранение предупреждений lint

### DIFF
--- a/src/components/ChatCard.jsx
+++ b/src/components/ChatCard.jsx
@@ -41,3 +41,12 @@ export default function ChatCard({ message }) {
     </Card>
   );
 }
+
+ChatCard.propTypes = {
+  message: PropTypes.shape({
+    sender: PropTypes.string.isRequired,
+    created_at: PropTypes.string,
+    content: PropTypes.string,
+    file_url: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/InlineSpinner.jsx
+++ b/src/components/InlineSpinner.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 export default function InlineSpinner({ size = 20 }) {
   const px = typeof size === "number" ? `${size}px` : size;
@@ -28,3 +29,7 @@ export default function InlineSpinner({ size = 20 }) {
     </svg>
   );
 }
+
+InlineSpinner.propTypes = {
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+};

--- a/src/components/ObjectList.jsx
+++ b/src/components/ObjectList.jsx
@@ -1,4 +1,5 @@
 import { memo, useState } from "react";
+import PropTypes from "prop-types";
 import Spinner from "./Spinner";
 import ErrorMessage from "./ErrorMessage";
 import { Input } from "@/components/ui/input";
@@ -45,5 +46,17 @@ function ObjectList({
     </div>
   );
 }
+
+ObjectList.propTypes = {
+  objects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ),
+  loading: PropTypes.bool,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  onItemClick: PropTypes.func,
+};
 
 export default memo(ObjectList);

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -160,7 +160,7 @@ export default function DashboardPage() {
       params.set("tab", nextTab);
     }
     if (changed) setSearchParams(params, { replace: true });
-  }, [selected?.id, activeTab]);
+  }, [selected?.id, activeTab, searchParams, setSearchParams]);
 
   // Restore selection/tab from URL (and react to browser navigation)
   useEffect(() => {
@@ -184,7 +184,7 @@ export default function DashboardPage() {
         handleSelect(found);
       }
     }
-  }, [searchParams, objects, selected]);
+  }, [searchParams, objects, selected, activeTab, handleSelect]);
 
   // Fetch total tasks count for header; keep updated via realtime
   useEffect(() => {


### PR DESCRIPTION
## Summary
- дописаны PropTypes для InlineSpinner, ChatCard и ObjectList
- исправлены зависимости useEffect в DashboardPage для прохождения lint

## Testing
- `npm test` *(падает: Failed prop type, отсутствующие элементы и другие ошибки)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c22917348324a48ea960916a4176