### PR TITLE
feat: validate environment variables with zod

### DIFF
--- a/src/apiConfig.ts
+++ b/src/apiConfig.ts
@@ -1,15 +1,7 @@
-/* global process */
-import logger from "./utils/logger";
+import { VITE_API_BASE_URL } from "./env";
 
-const apiBaseUrl: string | undefined =
-  import.meta.env?.VITE_API_BASE_URL || process.env.VITE_API_BASE_URL;
-
-export const isApiConfigured = Boolean(apiBaseUrl);
-
-if (!isApiConfigured) {
-  logger.error(
-    "VITE_API_BASE_URL is not set. Application runs in limited mode.",
-  );
-}
+const apiBaseUrl: string = VITE_API_BASE_URL;
 
 export { apiBaseUrl };
+
+export const isApiConfigured = Boolean(apiBaseUrl);

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,29 @@
+/* global process */
+import { z } from "zod";
+
+const envSchema = z.object({
+  VITE_API_BASE_URL: z.string().url(),
+  VITE_SUPABASE_URL: z.string().url(),
+  VITE_SUPABASE_ANON_KEY: z.string().min(1),
+});
+
+const parsedEnv = envSchema.safeParse({
+  VITE_API_BASE_URL:
+    process.env.VITE_API_BASE_URL || import.meta.env?.VITE_API_BASE_URL,
+  VITE_SUPABASE_URL:
+    process.env.VITE_SUPABASE_URL || import.meta.env?.VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY:
+    process.env.VITE_SUPABASE_ANON_KEY ||
+    import.meta.env?.VITE_SUPABASE_ANON_KEY,
+});
+
+if (!parsedEnv.success) {
+  throw new Error(
+    "Missing or invalid environment variables: " +
+      JSON.stringify(parsedEnv.error.format()),
+  );
+}
+
+export const env = parsedEnv.data;
+export const { VITE_API_BASE_URL, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } =
+  env;

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,36 +1,10 @@
-// @ts-check
-/* global process */
 import { createClient } from "@supabase/supabase-js";
-import logger from "./utils/logger";
 
-const supabaseUrl =
-  import.meta.env?.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-const supabaseKey =
-  import.meta.env?.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+import { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } from "./env";
+
+const supabaseUrl = VITE_SUPABASE_URL;
+const supabaseKey = VITE_SUPABASE_ANON_KEY;
 
 export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseKey);
 
-/** @type {import('@supabase/supabase-js').SupabaseClient} */
-let supabase;
-
-if (!isSupabaseConfigured) {
-  logger.error("VITE_SUPABASE_URL and/or VITE_SUPABASE_ANON_KEY are not set.");
-  /** @type {ProxyHandler<any>} */
-  const handler = {
-    get() {
-      return new Proxy(() => {
-        logger.error("Supabase not available: invalid configuration.");
-        return Promise.reject(new Error("Supabase is not configured"));
-      }, handler);
-    },
-    apply() {
-      logger.error("Supabase not available: invalid configuration.");
-      return Promise.reject(new Error("Supabase is not configured"));
-    },
-  };
-  supabase = /** @type {any} */ (new Proxy(() => {}, handler));
-} else {
-  supabase = createClient(supabaseUrl, supabaseKey);
-}
-
-export { supabase };
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- validate critical environment variables with zod
- use validated env values in apiConfig and supabase client

## Testing
- `npm test` *(fails: tests/AuthPage.test.jsx > AuthPage > регистрирует пользователя без создания профиля; src/components/__tests__/TaskCard.test.jsx > TaskCard > показывает кнопки при наличии прав; tests/App.test.jsx > App > отображает индикатор загрузки и страницу авторизации по /auth; etc.)*
- `npm run lint` *(fails: import/order errors across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4a4d7668832488ec2619557c2a31