### PR TITLE
feat: добавить заголовки безопасности

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,15 @@
 // vite.config.js
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import path from "path";
-import { fileURLToPath } from "url";
-import viteCompression from "vite-plugin-compression";
-import viteImagemin from "@vheemstra/vite-plugin-imagemin";
-import imageminMozjpeg from "imagemin-mozjpeg";
-import imageminPngquant from "imagemin-pngquant";
 import { env } from "node:process";
 import process from "node:process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import viteImagemin from "@vheemstra/vite-plugin-imagemin";
+import react from "@vitejs/plugin-react";
+import imageminMozjpeg from "imagemin-mozjpeg";
+import imageminPngquant from "imagemin-pngquant";
+import { defineConfig } from "vite";
+import viteCompression from "vite-plugin-compression";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -16,6 +17,14 @@ export default defineConfig(async ({ mode }) => {
   const isProd = mode === "production";
   const enableBrotli = process.env.ENABLE_BROTLI === "true";
   const rollupPlugins = [];
+
+  const securityHeaders = {
+    "Content-Security-Policy":
+      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self';",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+  };
 
   if (env.ANALYZE === "true") {
     const { visualizer } = await import("rollup-plugin-visualizer");
@@ -74,6 +83,10 @@ export default defineConfig(async ({ mode }) => {
       host: true, // 0.0.0.0
       port: 5173,
       strictPort: true,
+      headers: securityHeaders,
+    },
+    preview: {
+      headers: securityHeaders,
     },
   };
 });


### PR DESCRIPTION
## Summary
- добавить Content-Security-Policy и связанные заголовки
- включить политики в dev и preview сервере Vite

## Testing
- `npm test`
- `curl -I http://localhost:4173`

------
https://chatgpt.com/codex/tasks/task_e_68bd4a4ead288324aae573f5c82ea4ea