### PR TITLE
Add web vitals metrics collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-window": "^1.8.10",
         "tailwind-merge": "^3.3.1",
         "uuid": "^11.1.0",
+        "web-vitals": "^4.2.4",
         "zod": "^4.1.5"
       },
       "devDependencies": {
@@ -23044,6 +23045,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-window": "^1.8.10",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.1.0",
+    "web-vitals": "^4.2.4",
     "zod": "^4.1.5"
   },
   "devDependencies": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+
 import App from "./App";
 import "./index.css";
 import { AuthProvider } from "./context/AuthContext";
+import { initWebVitals } from "./utils/webVitals";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
@@ -11,3 +13,5 @@ createRoot(document.getElementById("root")).render(
     </AuthProvider>
   </StrictMode>,
 );
+
+initWebVitals();

--- a/src/utils/webVitals.js
+++ b/src/utils/webVitals.js
@@ -1,0 +1,12 @@
+import { onCLS, onFID, onLCP } from "web-vitals";
+
+/**
+ * Инициализирует сбор показателей веб-виталов и передает их
+ * в переданный обработчик или выводит в консоль по умолчанию.
+ * @param {(metric: import("web-vitals").Metric) => void} [reporter]
+ */
+export const initWebVitals = (reporter = console.log) => {
+  onCLS(reporter);
+  onFID(reporter);
+  onLCP(reporter);
+};


### PR DESCRIPTION
## Summary
- install web-vitals
- log CLS, LCP and FID metrics
- initialize web-vitals module in app entry

## Testing
- `npm test` *(fails: multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4a52ae808324a842dba2a064cfd7