### PR TITLE
Добавлены Dockerfile и docker-compose для разработки

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Multi-stage Dockerfile for production build
+
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Run stage
+FROM nginx:alpine AS run
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  app:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"


### PR DESCRIPTION
## Summary
- add multistage Dockerfile for production
- add docker-compose with hot reload for local development

## Testing
- `npm test` *(fails: process hangs, see logs)*
- `docker build -t inventory-app-prod .` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4a54fca48324b90be44f3e22b917