### PR TITLE
test: add deno tests for supabase edge functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,18 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  deno-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno test supabase/functions/**/index.test.ts
+
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, deno-tests]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -47,7 +56,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, deno-tests]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ npm test
 npm run e2e
 ```
 
+- Deno‑тесты edge‑функций:
+
+```bash
+deno test supabase/functions/**/index.test.ts
+```
+
 ## Деплой
 
 - Выполните SQL из `supabase/migrations/*.sql` через Supabase SQL Editor или используйте Supabase CLI: `supabase db push`.

--- a/supabase/functions/cacheGet/index.test.ts
+++ b/supabase/functions/cacheGet/index.test.ts
@@ -1,0 +1,177 @@
+import {
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
+import { handleRequest, type CacheGetDependencies } from "./index.ts";
+
+Deno.test("OPTIONS запрос возвращает 200", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "OPTIONS" }),
+  );
+  assertStrictEquals(response.status, 200);
+});
+
+Deno.test("отсутствующий параметр table возвращает 400", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "GET" }),
+  );
+  assertStrictEquals(response.status, 400);
+  assertEquals(await response.json(), { error: "table is required" });
+});
+
+Deno.test("запрещённая таблица возвращает 403", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com?table=forbidden", { method: "GET" }),
+  );
+  assertStrictEquals(response.status, 403);
+  assertEquals(await response.json(), { error: "table is not allowed" });
+});
+
+function createAuthFailureDeps(): CacheGetDependencies {
+  return {
+    createSupabaseClient: () => ({
+      auth: {
+        getUser: async () => ({ data: null, error: { message: "nope" } }),
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      }),
+    }),
+    createRedisClient: () => ({
+      get: async () => null,
+      set: async () => {},
+      del: async () => {},
+    }),
+  };
+}
+
+Deno.test("неавторизованный пользователь получает 401", async () => {
+  const request = new Request("https://example.com?table=objects", {
+    method: "GET",
+    headers: { Authorization: "Bearer token" },
+  });
+  const response = await handleRequest(request, createAuthFailureDeps());
+  assertStrictEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "unauthorized" });
+});
+
+Deno.test("возвращает данные из кеша", async () => {
+  const request = new Request("https://example.com?table=objects", {
+    method: "GET",
+    headers: { Authorization: "Bearer token" },
+  });
+  const deps: CacheGetDependencies = {
+    createSupabaseClient: () => ({
+      auth: {
+        getUser: async () => ({ data: { user: {} }, error: null }),
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      }),
+    }),
+    createRedisClient: () => ({
+      get: async () => JSON.stringify({ data: [{ id: 1 }] }),
+      set: async () => {
+        throw new Error("set не должен вызываться");
+      },
+      del: async () => {},
+    }),
+  };
+
+  const response = await handleRequest(request, deps);
+  assertStrictEquals(response.status, 200);
+  assertStrictEquals(response.headers.get("X-Cache"), "HIT");
+  assertEquals(await response.json(), { data: [{ id: 1 }] });
+});
+
+Deno.test(
+  "обращается к БД и записывает результат в кеш при промахе",
+  async () => {
+    const request = new Request("https://example.com?table=objects", {
+      method: "GET",
+      headers: { Authorization: "Bearer token" },
+    });
+    const setCalls: { key: string; value: string }[] = [];
+    const deps: CacheGetDependencies = {
+      createSupabaseClient: () => ({
+        auth: {
+          getUser: async () => ({ data: { user: {} }, error: null }),
+        },
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { id: 1 }, error: null }),
+            }),
+          }),
+        }),
+      }),
+      createRedisClient: () => ({
+        get: async () => null,
+        set: async (key: string, value: string) => {
+          setCalls.push({ key, value });
+        },
+        del: async () => {},
+      }),
+    };
+
+    const response = await handleRequest(
+      new Request("https://example.com?table=objects&id=1", {
+        method: "GET",
+        headers: { Authorization: "Bearer token" },
+      }),
+      deps,
+    );
+
+    assertStrictEquals(response.status, 200);
+    assertStrictEquals(response.headers.get("X-Cache"), "MISS");
+    assertEquals(await response.json(), { data: { id: 1 } });
+    assertEquals(setCalls, [
+      { key: "objects:1", value: JSON.stringify({ data: { id: 1 } }) },
+    ]);
+  },
+);
+
+Deno.test("удаление инвалидирует кеш", async () => {
+  const deletions: string[] = [];
+  const deps: CacheGetDependencies = {
+    createSupabaseClient: () => ({
+      auth: {
+        getUser: async () => ({ data: { user: {} }, error: null }),
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      }),
+    }),
+    createRedisClient: () => ({
+      get: async () => null,
+      set: async () => {},
+      del: async (key: string) => {
+        deletions.push(key);
+      },
+    }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com?table=objects&id=3", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer token" },
+    }),
+    deps,
+  );
+
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), { status: "invalidated" });
+  assertEquals(deletions, ["objects:3"]);
+});

--- a/supabase/functions/export/index.test.ts
+++ b/supabase/functions/export/index.test.ts
@@ -1,0 +1,346 @@
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
+import { handleRequest, type ExportDependencies } from "./index.ts";
+
+type AuthResult = {
+  data: {
+    user: { app_metadata?: { roles?: string[] }; [key: string]: unknown };
+  } | null;
+  error: { message: string } | null;
+};
+
+type QueryLogEntry = {
+  table: string;
+  filters: Record<string, string>;
+  ranges: Array<{ start: number; end: number; columns?: string[] }>;
+};
+
+type SupabaseStubOptions = {
+  authResult: AuthResult;
+  tableData?: Record<string, Array<Record<string, unknown>>>;
+  tableErrors?: Record<string, { message: string } | null>;
+  queryLog: QueryLogEntry[];
+};
+
+function createSupabaseStub({
+  authResult,
+  tableData = {},
+  tableErrors = {},
+  queryLog,
+}: SupabaseStubOptions): any {
+  return {
+    auth: {
+      getUser: async () => authResult,
+    },
+    from(table: string) {
+      const rows = tableData[table] ?? [];
+      const tableError = tableErrors[table] ?? null;
+      return {
+        select(columnsRaw: string) {
+          const columns =
+            columnsRaw === "*" ? undefined : columnsRaw.split(",");
+          const entry: QueryLogEntry = { table, filters: {}, ranges: [] };
+          queryLog.push(entry);
+          const builder: any = {
+            eq(column: string, value: string) {
+              entry.filters[column] = value;
+              return builder;
+            },
+            async range(start: number, end: number) {
+              entry.ranges.push({ start, end, columns });
+              if (tableError) {
+                return { data: null, error: tableError };
+              }
+              const filtered = rows.filter((row) =>
+                Object.entries(entry.filters).every(
+                  ([key, value]) => row[key] === value,
+                ),
+              );
+              const slice = filtered.slice(start, end + 1).map((row) => {
+                if (!columns) return row;
+                const picked: Record<string, unknown> = {};
+                for (const column of columns) {
+                  picked[column] = row[column];
+                }
+                return picked;
+              });
+              return { data: slice, error: null };
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+Deno.test("возвращает 400 при отсутствии параметров", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com/export"),
+  );
+  assertStrictEquals(response.status, 400);
+  assertEquals(await response.text(), "Missing parameters");
+});
+
+Deno.test("запрещённая таблица возвращает 403", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com/export/forbidden/csv"),
+  );
+  assertStrictEquals(response.status, 403);
+  assertEquals(await response.text(), "Forbidden");
+});
+
+Deno.test("ошибка авторизации возвращает 401", async () => {
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: { data: null, error: { message: "no" } },
+        queryLog: [],
+      }),
+    csvStringify: () => "",
+    createWorkbookWriter: () => ({
+      addWorksheet: () => ({
+        addRow: () => ({ commit() {} }),
+        commit() {},
+      }),
+      commit: async () => {},
+    }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/csv"),
+    deps,
+  );
+  assertStrictEquals(response.status, 401);
+  assertEquals(await response.text(), "Unauthorized");
+});
+
+Deno.test("пользователь без роли admin получает 403", async () => {
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: {
+          data: { user: { app_metadata: { roles: ["user"] } } },
+          error: null,
+        },
+        queryLog: [],
+      }),
+    csvStringify: () => "",
+    createWorkbookWriter: () => ({
+      addWorksheet: () => ({
+        addRow: () => ({ commit() {} }),
+        commit() {},
+      }),
+      commit: async () => {},
+    }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/csv"),
+    deps,
+  );
+  assertStrictEquals(response.status, 403);
+  assertEquals(await response.text(), "Forbidden");
+});
+
+Deno.test("CSV экспорт возвращает поток с данными по батчам", async () => {
+  const queryLog: QueryLogEntry[] = [];
+  const rows = Array.from({ length: 1100 }, (_, index) => ({
+    id: index,
+    name: `Item-${index}`,
+    status: index % 2 === 0 ? "open" : "closed",
+    extra: true,
+  }));
+  const csvCalls: Array<{ data: unknown[]; options: unknown }> = [];
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: {
+          data: { user: { app_metadata: { roles: ["admin"] } } },
+          error: null,
+        },
+        tableData: { objects: rows },
+        queryLog,
+      }),
+    csvStringify: (data, options) => {
+      csvCalls.push({ data, options });
+      return `chunk-${csvCalls.length}`;
+    },
+    createWorkbookWriter: () => ({
+      addWorksheet: () => ({
+        addRow: () => ({ commit() {} }),
+        commit() {},
+      }),
+      commit: async () => {},
+    }),
+  };
+
+  const response = await handleRequest(
+    new Request(
+      "https://example.com/export/objects/csv?columns=id,name&status=open",
+      { headers: { Authorization: "Bearer token" } },
+    ),
+    deps,
+  );
+
+  assertStrictEquals(response.status, 200);
+  assertStrictEquals(response.headers.get("Content-Type"), "text/csv");
+  const text = await response.text();
+  assertEquals(text, "chunk-1\nchunk-2\n");
+  assertEquals(csvCalls.length, 2);
+  const [firstCall, secondCall] = csvCalls;
+  assertEquals((firstCall.options as { header: boolean }).header, true);
+  assertEquals((secondCall.options as { header: boolean }).header, false);
+  assertEquals((firstCall.data as Record<string, unknown>[]).length, 1000);
+  assertEquals((secondCall.data as Record<string, unknown>[]).length, 100);
+  assertEquals(Object.keys((firstCall.data as Record<string, unknown>[])[0]), [
+    "id",
+    "name",
+  ]);
+  const entry = queryLog[0];
+  assertEquals(entry.table, "objects");
+  assertEquals(entry.filters, { status: "open" });
+  assertEquals(entry.ranges.slice(0, 2), [
+    { start: 0, end: 999, columns: ["id", "name"] },
+    { start: 1000, end: 1999, columns: ["id", "name"] },
+  ]);
+  assert(entry.ranges.length >= 2);
+});
+
+Deno.test("ошибка Supabase при CSV отдаёт 500", async () => {
+  const queryLog: QueryLogEntry[] = [];
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: {
+          data: { user: { app_metadata: { roles: ["admin"] } } },
+          error: null,
+        },
+        tableErrors: { objects: { message: "fail" } },
+        queryLog,
+      }),
+    csvStringify: () => "",
+    createWorkbookWriter: () => ({
+      addWorksheet: () => ({
+        addRow: () => ({ commit() {} }),
+        commit() {},
+      }),
+      commit: async () => {},
+    }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/csv"),
+    deps,
+  );
+  assertStrictEquals(response.status, 500);
+  assertEquals(await response.text(), "fail");
+});
+
+Deno.test("XLSX экспорт записывает строки и закрывает поток", async () => {
+  const queryLog: QueryLogEntry[] = [];
+  const rows = Array.from({ length: 2 }, (_, index) => ({
+    id: index,
+    name: `Item-${index}`,
+  }));
+  const worksheetState: {
+    columns?: { header: string; key: string }[];
+    rows: Record<string, unknown>[];
+    committed: boolean;
+  } = {
+    rows: [],
+    committed: false,
+  };
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: {
+          data: { user: { app_metadata: { roles: ["admin"] } } },
+          error: null,
+        },
+        tableData: { objects: rows },
+        queryLog,
+      }),
+    csvStringify: () => "",
+    createWorkbookWriter: ({ stream }) => {
+      const writer = stream.getWriter();
+      return {
+        addWorksheet: () => ({
+          get columns() {
+            return worksheetState.columns;
+          },
+          set columns(value) {
+            worksheetState.columns = value;
+          },
+          addRow: (row: Record<string, unknown>) => {
+            worksheetState.rows.push(row);
+            return { commit() {} };
+          },
+          commit() {},
+        }),
+        commit: async () => {
+          worksheetState.committed = true;
+          await writer.close();
+        },
+      };
+    },
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/xlsx?columns=id,name"),
+    deps,
+  );
+
+  assertStrictEquals(response.status, 200);
+  assertStrictEquals(
+    response.headers.get("Content-Type"),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  );
+  const body = await response.arrayBuffer();
+  assert(body.byteLength === 0);
+  assertEquals(worksheetState.columns, [
+    { header: "id", key: "id" },
+    { header: "name", key: "name" },
+  ]);
+  assertEquals(worksheetState.rows, rows);
+  assertEquals(worksheetState.committed, true);
+  assertEquals(queryLog[0].ranges.length, 1);
+});
+
+Deno.test("неподдерживаемый формат возвращает 400", async () => {
+  const deps: ExportDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({
+        authResult: {
+          data: { user: { app_metadata: { roles: ["admin"] } } },
+          error: null,
+        },
+        queryLog: [],
+      }),
+    csvStringify: () => "",
+    createWorkbookWriter: () => ({
+      addWorksheet: () => ({
+        addRow: () => ({ commit() {} }),
+        commit() {},
+      }),
+      commit: async () => {},
+    }),
+  };
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/json"),
+    deps,
+  );
+  assertStrictEquals(response.status, 400);
+  assertEquals(await response.text(), "Invalid format");
+});
+
+Deno.test("недопустимый ключ фильтра даёт 403", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com/export/objects/csv?invalid-key=value"),
+  );
+  assertStrictEquals(response.status, 403);
+  assertEquals(await response.text(), "Forbidden");
+});

--- a/supabase/functions/import-export/index.test.ts
+++ b/supabase/functions/import-export/index.test.ts
@@ -1,0 +1,70 @@
+import {
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
+import { handleRequest, type ImportExportDependencies } from "./index.ts";
+
+Deno.test("возвращает 401 при ошибке авторизации", async () => {
+  const deps: ImportExportDependencies = {
+    createSupabaseClient: () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: { user: null },
+            error: { message: "unauthorized" },
+          }),
+        },
+      }) as any,
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "GET" }),
+    deps,
+  );
+  assertStrictEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "Unauthorized" });
+});
+
+Deno.test("возвращает 403 если роль не подходит", async () => {
+  const deps: ImportExportDependencies = {
+    createSupabaseClient: () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: {
+              user: { app_metadata: { role: "viewer" }, user_metadata: {} },
+            },
+            error: null,
+          }),
+        },
+      }) as any,
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "GET" }),
+    deps,
+  );
+  assertStrictEquals(response.status, 403);
+  assertEquals(await response.json(), { error: "Forbidden" });
+});
+
+Deno.test("возвращает ok для допустимых ролей", async () => {
+  const deps: ImportExportDependencies = {
+    createSupabaseClient: () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: { user: { app_metadata: { role: "admin" } } },
+            error: null,
+          }),
+        },
+      }) as any,
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "GET" }),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), { message: "ok" });
+});

--- a/supabase/functions/import-export/index.ts
+++ b/supabase/functions/import-export/index.ts
@@ -1,18 +1,35 @@
 import { serve } from "std/server";
 import { createClient } from "@supabase/supabase-js";
 
-serve(async (req) => {
-  const supabase = createClient(
-    Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-    {
-      global: {
-        headers: {
-          Authorization: req.headers.get("Authorization") || "",
+export interface ImportExportDependencies {
+  createSupabaseClient?: (req: Request) => ReturnType<typeof createClient>;
+}
+
+const DEFAULT_DEPENDENCIES: Required<ImportExportDependencies> = {
+  createSupabaseClient: (req: Request) =>
+    createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      {
+        global: {
+          headers: {
+            Authorization: req.headers.get("Authorization") || "",
+          },
         },
       },
-    },
-  );
+    ),
+};
+
+export async function handleRequest(
+  req: Request,
+  dependencies: ImportExportDependencies = {},
+): Promise<Response> {
+  const { createSupabaseClient } = {
+    ...DEFAULT_DEPENDENCIES,
+    ...dependencies,
+  };
+
+  const supabase = createSupabaseClient(req);
 
   const {
     data: { user },
@@ -30,8 +47,11 @@ serve(async (req) => {
       status: 403,
     });
   }
-
   return new Response(JSON.stringify({ message: "ok" }), {
     headers: { "Content-Type": "application/json" },
   });
-});
+}
+
+if (import.meta.main) {
+  serve((req) => handleRequest(req));
+}

--- a/supabase/functions/import/index.test.ts
+++ b/supabase/functions/import/index.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
+import { handleRequest, type ImportDependencies } from "./index.ts";
+
+Deno.test("метод кроме POST запрещён", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "GET" }),
+  );
+  assertStrictEquals(response.status, 405);
+  assertEquals(await response.json(), {
+    error: "Only POST requests are allowed",
+  });
+});
+
+Deno.test("ошибка при отсутствии параметров формы", async () => {
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "POST" }),
+  );
+  assertStrictEquals(response.status, 400);
+  assertEquals(await response.json(), {
+    error: "Missing 'table' or 'file' in form data",
+  });
+});
+
+function createForm(table: string, file: File): FormData {
+  const form = new FormData();
+  form.set("table", table);
+  form.set("file", file);
+  return form;
+}
+
+Deno.test("возвращает 400 для неподдерживаемого расширения", async () => {
+  const file = new File(["content"], "data.txt", { type: "text/plain" });
+  const form = createForm("tasks", file);
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "POST", body: form }),
+  );
+  assertStrictEquals(response.status, 400);
+  assertEquals(await response.json(), { error: "Unsupported file type" });
+});
+
+Deno.test("проверяет обязательные поля и возвращает ошибки", async () => {
+  const file = new File(["a,b\n1,2"], "data.csv", { type: "text/csv" });
+  const calls: unknown[] = [];
+  const deps: ImportDependencies = {
+    parseCsv: () => [{ title: "", assignee: "", due_date: "" }],
+    parseXlsx: () => [],
+    createSupabaseClient: () =>
+      ({
+        from: () => ({
+          insert: async (rows: unknown[]) => {
+            calls.push(rows);
+            return { error: null };
+          },
+        }),
+      }) as any,
+  };
+  const form = createForm("tasks", file);
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "POST", body: form }),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), {
+    inserted: 0,
+    errors: [{ row: 2, error: "Missing fields: title, assignee, due_date" }],
+  });
+  assertEquals(calls, []);
+});
+
+Deno.test("успешно импортирует валидные записи", async () => {
+  const file = new File(["a,b\n1,2"], "data.csv", { type: "text/csv" });
+  const inserted: unknown[] = [];
+  const deps: ImportDependencies = {
+    parseCsv: () => [
+      { title: "Task", assignee: "John", due_date: "2024-01-01" },
+    ],
+    parseXlsx: () => [],
+    createSupabaseClient: () =>
+      ({
+        from: () => ({
+          insert: async (rows: unknown[]) => {
+            inserted.push(...rows);
+            return { error: null };
+          },
+        }),
+      }) as any,
+  };
+  const form = createForm("tasks", file);
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "POST", body: form }),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), { inserted: 1, errors: [] });
+  assertEquals(inserted, [
+    { title: "Task", assignee: "John", due_date: "2024-01-01" },
+  ]);
+});
+
+Deno.test("ошибка вставки попадает в список ошибок", async () => {
+  const file = new File(["a,b\n1,2"], "data.csv", { type: "text/csv" });
+  const deps: ImportDependencies = {
+    parseCsv: () => [
+      { title: "Task", assignee: "John", due_date: "2024-01-01" },
+    ],
+    parseXlsx: () => [],
+    createSupabaseClient: () =>
+      ({
+        from: () => ({
+          insert: async () => ({ error: { message: "fail" } }),
+        }),
+      }) as any,
+  };
+  const form = createForm("tasks", file);
+  const response = await handleRequest(
+    new Request("https://example.com", { method: "POST", body: form }),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), {
+    inserted: 0,
+    errors: [{ row: 0, error: "fail" }],
+  });
+});

--- a/supabase/functions/slow-queries/index.test.ts
+++ b/supabase/functions/slow-queries/index.test.ts
@@ -1,0 +1,86 @@
+import {
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
+import { handleRequest, type SlowQueriesDependencies } from "./index.ts";
+
+type QueryResult = { data: any[] | null; error: { message: string } | null };
+
+function createSupabaseStub(result: QueryResult, inserted: any[] = []): any {
+  return {
+    from(table: string) {
+      if (table === "pg_stat_statements") {
+        return {
+          select: () => ({
+            gt: () => Promise.resolve(result),
+          }),
+        };
+      }
+      if (table === "slow_query_logs") {
+        return {
+          insert: async (rows: any[]) => {
+            inserted.push(...rows);
+            return { error: null };
+          },
+        };
+      }
+      throw new Error("unexpected table");
+    },
+  };
+}
+
+Deno.test("возвращает 500 при ошибке Supabase", async () => {
+  const deps: SlowQueriesDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub({ data: null, error: { message: "boom" } }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com"),
+    deps,
+  );
+  assertStrictEquals(response.status, 500);
+  assertEquals(await response.text(), "boom");
+});
+
+Deno.test("сохраняет найденные запросы", async () => {
+  const inserted: any[] = [];
+  const deps: SlowQueriesDependencies = {
+    createSupabaseClient: () =>
+      createSupabaseStub(
+        {
+          data: [
+            { query: "select 1", mean_time: 600, calls: 3 },
+            { query: "select 2", mean_time: 800, calls: 1 },
+          ],
+          error: null,
+        },
+        inserted,
+      ),
+    thresholdMs: 500,
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com"),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), { stored: 2 });
+  assertEquals(inserted, [
+    { query: "select 1", mean_time: 600, calls: 3 },
+    { query: "select 2", mean_time: 800, calls: 1 },
+  ]);
+});
+
+Deno.test("возвращает stored 0 когда данных нет", async () => {
+  const deps: SlowQueriesDependencies = {
+    createSupabaseClient: () => createSupabaseStub({ data: [], error: null }),
+  };
+
+  const response = await handleRequest(
+    new Request("https://example.com"),
+    deps,
+  );
+  assertStrictEquals(response.status, 200);
+  assertEquals(await response.json(), { stored: 0 });
+});


### PR DESCRIPTION
## Summary
- refactor Supabase edge functions to export testable handlers with dependency injection
- add Deno-based test suites covering cache, import/export, and slow query behaviours
- document and wire deno test execution into the CI pipeline

## Testing
- deno test supabase/functions/**/index.test.ts *(fails: Deno CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1306dbbe48324a94b19457c991b5e